### PR TITLE
Fix missing module error

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,6 @@ from flask import Blueprint, render_template, jsonify, request
 import folium
 from app.map_utils import update_map_with_timeline_data
 from app.utils.json_processing_functions import print_unique_visits_to_csv
-from app.utils.mapbox_processing_functions import reverse_geocode_timeline_csv
 
 main = Blueprint('main', __name__)
 


### PR DESCRIPTION
## Summary
- remove unused import for nonexistent Mapbox functions

## Testing
- `python -m py_compile app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6861d25c3c08832981c7175b9a6cdd49