### PR TITLE
Fix update_timeline data directory

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -52,7 +52,10 @@ def api_update_timeline():
     
         # Reverse geocode all unique locations to get addresses via Mapbox API call into 'timeline_unique_visits.csv" in, data/ folder
         # This is what's actually going to be rendered into map markers
-        csv_path = os.path.join('data', 'master_timeline_data.csv')       #creating the target file path
+        csv_path = os.path.join('data', 'master_timeline_data.csv')  # creating the target file path
+
+        # Ensure the data directory exists before attempting to write the CSV
+        os.makedirs('data', exist_ok=True)
         print_unique_visits_to_csv(timeline_json, csv_path, 'google_timeline')
 
         # Ensure the CSV file was created successfully


### PR DESCRIPTION
## Summary
- ensure `data` folder is created before saving master timeline data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861d2784b008329b48bb7ecbf2a6c41