### PR TITLE
Cache timeline data for map rendering

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,10 +2,15 @@ import os
 from flask import Flask
 from dotenv import load_dotenv
 
+from . import data_cache
+
 def create_app():
     load_dotenv()
 
     app = Flask(__name__)
+
+    # Load cached timeline data once during application startup
+    data_cache.load_timeline_data()
 
     from .routes import main
     app.register_blueprint(main)

--- a/app/data_cache.py
+++ b/app/data_cache.py
@@ -1,0 +1,24 @@
+import os
+import pandas as pd
+
+# Path to the master timeline CSV
+CSV_PATH = os.path.join('data', 'master_timeline_db.csv')
+
+# Cached pandas DataFrame
+timeline_df = None
+
+def load_timeline_data():
+    """Load the timeline CSV into ``timeline_df`` if present."""
+    global timeline_df
+
+    if os.path.exists(CSV_PATH):
+        try:
+            timeline_df = pd.read_csv(CSV_PATH)
+            print(f"Loaded {len(timeline_df)} rows from {CSV_PATH}")
+        except Exception as exc:
+            print(f"Failed to load {CSV_PATH}: {exc}")
+            timeline_df = None
+    else:
+        print(f"CSV file {CSV_PATH} not found. Continuing without cached data.")
+        timeline_df = None
+

--- a/app/map_utils.py
+++ b/app/map_utils.py
@@ -3,11 +3,21 @@ import pandas as pd
 import folium
 from folium.plugins import MarkerCluster
 
-def update_map_with_timeline_data(input_map, input_file):
-    """Reads location data from CSV and adds markers to a folium map."""
-    print(f"Loading data from: {input_file}")
-    df = pd.read_csv(input_file)
-    print(f"Loaded {len(df)} locations from CSV")
+from . import data_cache
+
+def update_map_with_timeline_data(input_map, input_file=None, df=None):
+    """Add markers to ``input_map`` using timeline data."""
+
+    if df is None:
+        if data_cache.timeline_df is not None:
+            df = data_cache.timeline_df
+            print(f"Using cached timeline data ({len(df)} rows)")
+        elif input_file and os.path.exists(input_file):
+            print(f"Loading data from: {input_file}")
+            df = pd.read_csv(input_file)
+        else:
+            print("No timeline data available to render on map")
+            return
 
     popup_css = """
         <style>

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,7 +2,9 @@ import os
 import json
 from flask import Blueprint, render_template, jsonify, request
 import folium
+import pandas as pd
 from app.map_utils import update_map_with_timeline_data
+from . import data_cache
 from app.utils.json_processing_functions import print_unique_visits_to_csv
 from app.utils.mapbox_processing_functions import reverse_geocode_timeline_csv
 
@@ -62,8 +64,12 @@ def api_update_timeline():
               message=f"CSV file '{csv_path}' not found after processing."
             ), 500
 
-        # Update the Folium map with data from the CSV
-        update_map_with_timeline_data(m, csv_path)
+        # Load the CSV into a DataFrame and update the cache
+        df = pd.read_csv(csv_path)
+        data_cache.timeline_df = df
+
+        # Update the Folium map with the new data
+        update_map_with_timeline_data(m, df=df)
 
         #  Return success message
         return jsonify(


### PR DESCRIPTION
## Summary
- load `data/master_timeline_db.csv` once during app startup
- store cached dataframe in new `data_cache` module
- use cached dataframe in map utilities
- update routes to refresh the cache when new timeline data is uploaded

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861d28870dc8329ac237a43dfa4ba5c