### PR TITLE
Implement timeline persistence

### DIFF
--- a/app/data_cache.py
+++ b/app/data_cache.py
@@ -22,3 +22,18 @@ def load_timeline_data():
         print(f"CSV file {CSV_PATH} not found. Continuing without cached data.")
         timeline_df = None
 
+def save_timeline_data():
+    """Persist ``timeline_df`` to ``CSV_PATH`` if data is available."""
+    global timeline_df
+
+    if timeline_df is None:
+        print("No timeline data to save.")
+        return
+
+    try:
+        os.makedirs(os.path.dirname(CSV_PATH), exist_ok=True)
+        timeline_df.to_csv(CSV_PATH, index=False)
+        print(f"Saved {len(timeline_df)} rows to {CSV_PATH}")
+    except Exception as exc:
+        print(f"Failed to save {CSV_PATH}: {exc}")
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -69,6 +69,8 @@ def api_update_timeline():
         # Load the CSV into a DataFrame and update the cache
         df = pd.read_csv(csv_path)
         data_cache.timeline_df = df
+        # Persist the updated timeline if required
+        data_cache.save_timeline_data()
 
         # Update the Folium map with the new data
         update_map_with_timeline_data(m, df=df)


### PR DESCRIPTION
## Summary
- cache timeline CSV with a new `save_timeline_data` helper
- persist timeline updates when `/api/update_timeline` processes a file

## Testing
- `python -m py_compile app/data_cache.py app/routes.py`
- `flake8 app/data_cache.py app/routes.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e4526f28832988f9930f29ef74a2