### PR TITLE
Add source type filtering

### DIFF
--- a/app/map_utils.py
+++ b/app/map_utils.py
@@ -5,8 +5,23 @@ from folium.plugins import MarkerCluster
 
 from . import data_cache
 
-def update_map_with_timeline_data(input_map, input_file=None, df=None):
-    """Add markers to ``input_map`` using timeline data."""
+
+def update_map_with_timeline_data(
+    input_map, input_file=None, df=None, source_type=None
+):
+    """Add markers to ``input_map`` using timeline data.
+
+    Parameters
+    ----------
+    input_map : folium.Map
+        Map instance to update.
+    input_file : str, optional
+        CSV file containing timeline data.
+    df : pandas.DataFrame, optional
+        DataFrame of timeline data to render.
+    source_type : str, optional
+        If provided, only rows matching this ``Source Type`` value are used.
+    """
 
     if df is None:
         if data_cache.timeline_df is not None:
@@ -18,6 +33,11 @@ def update_map_with_timeline_data(input_map, input_file=None, df=None):
         else:
             print("No timeline data available to render on map")
             return
+
+    if source_type:
+        before = len(df)
+        df = df[df.get("Source Type") == source_type]
+        print(f"Filtered timeline data from {before} to {len(df)} rows by source '{source_type}'")
 
     popup_css = """
         <style>

--- a/app/routes.py
+++ b/app/routes.py
@@ -97,3 +97,21 @@ def api_clear():
     )
     m.save('map.html')
     return jsonify({'status': 'success', 'message': 'Map cleared successfully.'})
+
+
+@main.route('/api/render_map', methods=['POST'])
+def api_render_map():
+    """Refresh the map with optional filtering by source type."""
+
+    df = data_cache.timeline_df
+    if df is None or df.empty:
+        return jsonify(status='error', message='No timeline data loaded.'), 400
+
+    data = request.get_json(silent=True) or {}
+    source_type = data.get('source_type')
+    if source_type:
+        df = df[df.get('Source Type') == source_type]
+
+    update_map_with_timeline_data(m, df=df, source_type=source_type)
+
+    return jsonify({'status': 'success', 'message': 'Map refreshed.'})

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -175,6 +175,10 @@
                     <button class="overlay-button" onclick="clearMap()">
                         🗑️ Clear Markers
                     </button>
+                    <select id="sourceTypeFilter" class="overlay-button">
+                        <option value="">All Sources</option>
+                        <option value="google_timeline">Google Timeline</option>
+                    </select>
                     <button class="overlay-button" onclick="refreshMap()">
                         🔄 Refresh Map
                     </button>
@@ -277,6 +281,31 @@
                 try {
                     const response = await fetch('/api/clear', { 
                         method: 'POST'
+                    });
+                    const result = await response.json();
+                    hideLoading();
+                    showStatus(result.message, result.status === 'error');
+                    if (result.status === 'success') {
+                        setTimeout(refreshMapFrame, 500);
+                    }
+                } catch (error) {
+                    hideLoading();
+                    showStatus('Error: ' + error.message, true);
+                }
+            }
+
+            /**
+             * Refresh map with the selected source type filter
+             */
+            async function refreshMap() {
+                showLoading();
+                const sourceType = document.getElementById('sourceTypeFilter').value;
+
+                try {
+                    const response = await fetch('/api/render_map', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ source_type: sourceType })
                     });
                     const result = await response.json();
                     hideLoading();


### PR DESCRIPTION
## Summary
- allow filtering data in `update_map_with_timeline_data`
- expose new `/api/render_map` endpoint with optional `source_type`
- add dropdown and `refreshMap()` JS handler in the UI

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68632529abe88329bd27b63fdfcdccb5