### PR TITLE
Improve map rendering performance

### DIFF
--- a/app/map_utils.py
+++ b/app/map_utils.py
@@ -6,7 +6,12 @@ from folium.plugins import MarkerCluster
 from . import data_cache
 
 def update_map_with_timeline_data(input_map, input_file=None, df=None):
-    """Add markers to ``input_map`` using timeline data."""
+    """Add markers to ``input_map`` using timeline data.
+
+    This function now clears previously rendered markers so that only the
+    provided ``df`` data is shown.  It also iterates over the DataFrame in a
+    more efficient manner to better support large datasets.
+    """
 
     if df is None:
         if data_cache.timeline_df is not None:
@@ -18,6 +23,21 @@ def update_map_with_timeline_data(input_map, input_file=None, df=None):
         else:
             print("No timeline data available to render on map")
             return
+
+    if df.empty:
+        print("Provided DataFrame is empty. Nothing to render.")
+        return
+
+    # ------------------------------------------------------------------
+    # Remove any previously rendered layers so filtered results don't
+    # accumulate with old data.  Keep the base tile layers intact.
+    # ------------------------------------------------------------------
+    keys_to_remove = [
+        key for key, val in list(input_map._children.items())
+        if not isinstance(val, folium.raster_layers.TileLayer)
+    ]
+    for key in keys_to_remove:
+        del input_map._children[key]
 
     popup_css = """
         <style>
@@ -105,61 +125,46 @@ def update_map_with_timeline_data(input_map, input_file=None, df=None):
         icon_create_function=icon_create_function
     ).add_to(input_map)
 
-    for _, row in df.iterrows():
-        popup_html = f"""
-        {popup_css}
-        <div style="
-            font-family: Arial, sans-serif;
-            width: 220px;
-            padding: 15px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            border-radius: 15px;
-            box-shadow: 0 8px 20px rgba(0,0,0,0.3);
-            border: 2px solid rgba(255,255,255,0.2);
-            position: relative;
-        ">
-            <h3 style="margin: 0 0 10px 0; color: #fff; font-size: 16px;">
-                📍 Location Details
-            </h3>
-            <p style="margin: 5px 0; font-size: 12px;">
-                <strong>Place Name:</strong> {row['Place Name']}
-            </p>
-            <p style="margin: 5px 0; font-size: 12px;">
-                <strong>Date Visited:</strong> {row['Start Date']}
-            </p>
-            <p style="margin: 5px 0; font-size: 12px;">
-                <strong>Coordinates:</strong><br>
-                Lat: {row['Latitude']:.4f}<br>
-                Lng: {row['Longitude']:.4f}
-            </p>
-            
-            <!-- Custom arrow pointing down -->
-            <div style="
-                position: absolute;
-                bottom: -10px;
-                left: 50%;
-                transform: translateX(-50%);
-                width: 0;
-                height: 0;
-                border-left: 10px solid transparent;
-                border-right: 10px solid transparent;
-                border-top: 10px solid #764ba2;
-            "></div>
+    popup_template = (
+        """
+        {css}
+        <div style="font-family: Arial, sans-serif; width: 220px; padding: 15px;"
+        " background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color:"
+        " white; border-radius: 15px; box-shadow: 0 8px 20px rgba(0,0,0,0.3);"
+        " border: 2px solid rgba(255,255,255,0.2); position: relative;">
+            <h3 style=\"margin: 0 0 10px 0; color: #fff; font-size: 16px;\">📍 Location Details</h3>
+            <p style=\"margin: 5px 0; font-size: 12px;\"><strong>Place Name:</strong> {name}</p>
+            <p style=\"margin: 5px 0; font-size: 12px;\"><strong>Date Visited:</strong> {date}</p>
+            <p style=\"margin: 5px 0; font-size: 12px;\"><strong>Coordinates:</strong><br>Lat: {lat:.4f}<br>Lng: {lon:.4f}</p>
+            <div style="position: absolute; bottom: -10px; left: 50%; transform: translateX(-50%); width: 0; height: 0; border-left: 10px solid transparent; border-right: 10px solid transparent; border-top: 10px solid #764ba2;"></div>
         </div>
         """
-        custom_icon = None
+    )
 
-        if os.path.exists('app/static/assets/marker.png'):
-            custom_icon = folium.CustomIcon(
-                icon_image='app/static/assets/marker.png',
-                icon_size=(40, 40),
-                icon_anchor=(20, 40),
-                popup_anchor=(0, -40)
-            )
+    icon_path = 'app/static/assets/marker.png'
+    custom_icon = None
+    if os.path.exists(icon_path):
+        custom_icon = folium.CustomIcon(
+            icon_image=icon_path,
+            icon_size=(40, 40),
+            icon_anchor=(20, 40),
+            popup_anchor=(0, -40)
+        )
+
+    for row in df.itertuples(index=False):
+        rdict = row._asdict()
+        name = rdict.get('Place_Name') or rdict.get('Place Name')
+        date = rdict.get('Start_Date') or rdict.get('Start Date')
+        popup_html = popup_template.format(
+            css=popup_css,
+            name=name,
+            date=date,
+            lat=row.Latitude,
+            lon=row.Longitude,
+        )
 
         folium.Marker(
-            location=[row['Latitude'], row['Longitude']],
+            location=[row.Latitude, row.Longitude],
             popup=folium.Popup(popup_html, max_width=250),
             icon=custom_icon
         ).add_to(marker_cluster)


### PR DESCRIPTION
## Summary
- avoid re-rendering all markers when filtering
- handle empty DataFrames and remove old layers before rendering
- iterate through records with `itertuples` and build HTML from a template

## Testing
- `python -m py_compile app/map_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686344d157908329bbc98071684fc4a9