### PR TITLE
Dynamic map marker updates

### DIFF
--- a/app/data_cache.py
+++ b/app/data_cache.py
@@ -37,3 +37,16 @@ def save_timeline_data():
     except Exception as exc:
         print(f"Failed to save {CSV_PATH}: {exc}")
 
+
+def clear_timeline_data():
+    """Remove cached timeline data and delete the CSV file if present."""
+    global timeline_df
+
+    timeline_df = None
+    if os.path.exists(CSV_PATH):
+        try:
+            os.remove(CSV_PATH)
+            print(f"Removed {CSV_PATH}")
+        except Exception as exc:
+            print(f"Failed to remove {CSV_PATH}: {exc}")
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,11 +3,8 @@
 import json
 import os
 
-import folium
 import pandas as pd
 from flask import Blueprint, jsonify, render_template, request
-
-from app.map_utils import update_map_with_timeline_data
 from app.utils.json_processing_functions import unique_visits_to_df
 from . import data_cache
 
@@ -15,21 +12,11 @@ main = Blueprint("main", __name__)
 
 MAPBOX_ACCESS_TOKEN = os.getenv("MAPBOX_ACCESS_TOKEN")
 
-# Create initial Folium map object with default settings. This in-memory
-# map is updated whenever new timeline data is uploaded.
-m = folium.Map(
-    location=[40.65997395108914, -73.71300111746832],
-    zoom_start=5,
-    min_zoom=3,
-    tiles=f"https://api.mapbox.com/styles/v1/mapbox/outdoors-v12/tiles/{{z}}/{{x}}/{{y}}?access_token={MAPBOX_ACCESS_TOKEN}",
-    attr='Mapbox'
-)
-
 @main.route('/')
 def index():
     """Render the landing page."""
 
-    return render_template("index.html")
+    return render_template("index.html", mapbox_access_token=MAPBOX_ACCESS_TOKEN)
 
 # Route to serve the current saved map HTML
 @main.route('/map')
@@ -61,17 +48,17 @@ def api_update_timeline():
         #Process the timeline.json file uploaded by the user into a pandas df.
         imported_df = unique_visits_to_df(timeline_json, "google_timeline")
         database_df = data_cache.timeline_df
-        #combine the imported data and resulting processed dataframe with the existing database info
-        combined = pd.concat([imported_df, database_df])
+        # combine the imported data with the existing database info
+        if database_df is not None:
+            combined = pd.concat([imported_df, database_df])
+        else:
+            combined = imported_df
         combined = combined.drop_duplicates()
         #update global database memory with appended information
         data_cache.timeline_df = combined
 
         # Persist the updated timeline if required
         data_cache.save_timeline_data()
-
-        # Update the Folium map with the new data
-        update_map_with_timeline_data(m, df=data_cache.timeline_df)
 
         #  Return success message
         return jsonify(
@@ -85,17 +72,9 @@ def api_update_timeline():
 
 @main.route('/api/clear', methods=['POST'])
 def api_clear():
-    """Clear all markers and reset the map state."""
+    """Clear all markers and reset the stored timeline data."""
 
-    global m
-    m = folium.Map(
-        location=[40.65997395108914, -73.71300111746832],
-        zoom_start=5,
-        min_zoom=3,
-        tiles=f"https://api.mapbox.com/styles/v1/mapbox/outdoors-v12/tiles/{{z}}/{{x}}/{{y}}?access_token={MAPBOX_ACCESS_TOKEN}",
-        attr='Mapbox'
-    )
-    m.save('map.html')
+    data_cache.clear_timeline_data()
     return jsonify({'status': 'success', 'message': 'Map cleared successfully.'})
 
 
@@ -112,17 +91,25 @@ def api_source_types():
 
 @main.route('/api/render_map', methods=['POST'])
 def api_render_map():
-    """Refresh the map with optional filtering by one or more source types."""
+    """Endpoint maintained for backwards compatibility."""
+
+    if data_cache.timeline_df is None or data_cache.timeline_df.empty:
+        return jsonify(status='error', message='No timeline data loaded.'), 400
+
+    return jsonify({'status': 'success', 'message': 'Map refreshed.'})
+
+
+@main.route('/api/markers', methods=['GET'])
+def api_markers():
+    """Return marker data optionally filtered by ``source_types`` query args."""
 
     df = data_cache.timeline_df
     if df is None or df.empty:
-        return jsonify(status='error', message='No timeline data loaded.'), 400
+        return jsonify([])
 
-    data = request.get_json(silent=True) or {}
-    source_types = data.get('source_types') or []
+    source_types = request.args.getlist('source_types')
     if source_types:
         df = df[df.get('Source Type').isin(source_types)]
 
-    update_map_with_timeline_data(m, df=df)
-
-    return jsonify({'status': 'success', 'message': 'Map refreshed.'})
+    markers = df[['Latitude', 'Longitude', 'Place Name', 'Start Date']].to_dict(orient='records')
+    return jsonify(markers)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,11 @@
 <html>
     <head>
         <title>Wanderlog Full-Screen Map</title>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+        <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
+        <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
+        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+        <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
         <style>
             /* CSS STYLES - Full-screen map with overlay buttons */
             * {
@@ -22,11 +27,10 @@
                 height: 100vh;
             }
             
-            /* Map iframe takes full screen */
+            /* Map container takes full screen */
             #map {
                 width: 100%;
                 height: 100%;
-                border: none;
             }
             
             /* Menu container positioned in the top-right */
@@ -172,8 +176,8 @@
     <body>
         <!-- Full-screen map container -->
         <div id="map-container">
-            <!-- Map iframe -->
-            <iframe id="map" src="{{ url_for('main.serve_map') }}"></iframe>
+            <!-- Map element rendered by Leaflet -->
+            <div id="map"></div>
             
             <!-- Hidden file input for importing Google Timeline JSON -->
             <input type="file" id="timelineFile" accept=".json" style="display:none" onchange="updateMap()">
@@ -241,13 +245,46 @@
                 setTimeout(() => status.style.display = 'none', 4000);
             }
             
+            let map;
+            let markerCluster;
+
             /**
-             * Refresh the map iframe by reloading it
+             * Initialize Leaflet map and fetch markers
              */
-            function refreshMapFrame() {
-                const mapFrame = document.getElementById('map');
-                // Add timestamp to URL to force refresh
-                mapFrame.src = '/map?' + new Date().getTime();
+            function initMap() {
+                map = L.map('map').setView([40.65997395108914, -73.71300111746832], 5);
+
+                L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/outdoors-v12/tiles/{z}/{x}/{y}?access_token={{ mapbox_access_token }}', {
+                    maxZoom: 18,
+                    attribution: 'Mapbox'
+                }).addTo(map);
+
+                markerCluster = L.markerClusterGroup();
+                map.addLayer(markerCluster);
+
+                loadMarkers();
+            }
+
+            /**
+             * Fetch marker data from server and update the map
+             */
+            async function loadMarkers() {
+                const checked = Array.from(document.querySelectorAll('#sourceTypeFilters input:checked')).map(cb => cb.value);
+                const params = new URLSearchParams();
+                checked.forEach(t => params.append('source_types', t));
+
+                const response = await fetch('/api/markers?' + params.toString());
+                const markers = await response.json();
+
+                markerCluster.clearLayers();
+                markers.forEach(m => {
+                    const marker = L.marker([m.Latitude, m.Longitude]);
+                    marker.bindPopup(
+                        `<div><strong>Place Name:</strong> ${m['Place Name']}<br>` +
+                        `<strong>Date Visited:</strong> ${m['Start Date']}</div>`
+                    );
+                    markerCluster.addLayer(marker);
+                });
             }
             
             /**
@@ -274,7 +311,7 @@
                 hideLoading();
                 showStatus(result.message, result.status === 'error');
                 if (result.status === 'success') {
-                    setTimeout(refreshMapFrame, 1000);
+                    setTimeout(loadMarkers, 500);
                 }
                 } catch (err) {
                 hideLoading();
@@ -296,7 +333,7 @@
                     hideLoading();
                     showStatus(result.message, result.status === 'error');
                     if (result.status === 'success') {
-                        setTimeout(refreshMapFrame, 500);
+                        setTimeout(loadMarkers, 300);
                     }
                 } catch (error) {
                     hideLoading();
@@ -306,27 +343,13 @@
 
             async function refreshMap() {
                 showLoading();
-                const checked = Array.from(document.querySelectorAll('#sourceTypeFilters input:checked')).map(cb => cb.value);
-
-                try {
-                    const response = await fetch('/api/render_map', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ source_types: checked })
-                    });
-                    const result = await response.json();
-                    hideLoading();
-                    showStatus(result.message, result.status === 'error');
-                    if (result.status === 'success') {
-                        setTimeout(refreshMapFrame, 500);
-                    }
-                } catch (error) {
-                    hideLoading();
-                    showStatus('Error: ' + error.message, true);
-                }
+                await loadMarkers();
+                hideLoading();
+                showStatus('Map refreshed.', false);
             }
 
             document.addEventListener('DOMContentLoaded', async () => {
+                initMap();
                 try {
                     const response = await fetch('/api/source_types');
                     const types = await response.json();


### PR DESCRIPTION
## Summary
- pass access token to index template
- clean up map routes and expose new `/api/markers` API
- keep timeline data cache manageable with `clear_timeline_data`
- render Leaflet map directly on the page and update markers dynamically

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863638409948329aed17a02b403035d