### PR TITLE
Add comments to new map APIs

### DIFF
--- a/app/map_utils.py
+++ b/app/map_utils.py
@@ -189,19 +189,22 @@ def update_map_with_timeline_data(
 def dataframe_to_markers(df: pd.DataFrame) -> list[dict]:
     """Return a simplified marker list from the timeline dataframe."""
 
+    # Return early if no timeline data is available
     if df is None or df.empty:
         return []
 
     markers = []
+    # Iterate over each row and build a small dict for the frontend
     for _, row in df.iterrows():
         markers.append(
             {
-                "lat": row["Latitude"],
-                "lng": row["Longitude"],
-                "place": row.get("Place Name", ""),
-                "date": row.get("Start Date", ""),
-                "source_type": row.get("Source Type", ""),
+                "lat": row["Latitude"],           # Latitude for the map marker
+                "lng": row["Longitude"],          # Longitude for the map marker
+                "place": row.get("Place Name", ""),  # Human readable place name
+                "date": row.get("Start Date", ""),   # Date when the place was visited
+                "source_type": row.get("Source Type", ""),  # Data source category
             }
         )
 
+    # The frontend expects a list of marker dictionaries
     return markers

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -69,33 +69,46 @@ function showStatus(message, isError=false) {
 }
 
 function initMap() {
+    // Create a Leaflet map centered on a default view
     map = L.map('map').setView([40.65997395108914, -73.71300111746832], 5);
+    // Add Mapbox tiles using the token passed from the backend
     L.tileLayer(`https://api.mapbox.com/styles/v1/mapbox/outdoors-v12/tiles/{z}/{x}/{y}?access_token=${MAPBOX_TOKEN}`, {
         maxZoom: 18,
         attribution: 'Mapbox'
     }).addTo(map);
+    // Cluster group keeps the map responsive when many markers are shown
     markerCluster = L.markerClusterGroup();
     map.addLayer(markerCluster);
+    // Load existing markers once the map is ready
     loadMarkers();
 }
 
 async function loadMarkers() {
+    // Show a loading overlay while fetching marker data
     showLoading();
+    // Remove any markers currently displayed
     markerCluster.clearLayers();
-    const checked = Array.from(document.querySelectorAll('#sourceTypeFilters input:checked')).map(cb => cb.value);
+    // Collect the values of all checked source type filters
+    const checked = Array.from(
+        document.querySelectorAll('#sourceTypeFilters input:checked')
+    ).map(cb => cb.value);
     try {
+        // Request the marker list from the server, filtering by source type
         const response = await fetch('/api/map_data', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ source_types: checked })
         });
+        // Parse the JSON response
         const markers = await response.json();
+        // Add a Leaflet marker for each item returned
         markers.forEach(m => {
             const popup = `<div><strong>Place Name:</strong> ${m.place}<br>` +
                           `<strong>Date Visited:</strong> ${m.date}<br>` +
                           `<strong>Coordinates:</strong> ${m.lat.toFixed(4)}, ${m.lng.toFixed(4)}</div>`;
             L.marker([m.lat, m.lng]).bindPopup(popup).addTo(markerCluster);
         });
+        // Done loading
         hideLoading();
     } catch(err) {
         hideLoading();


### PR DESCRIPTION
## Summary
- document dataframe_to_markers helper
- expand docstring for api_map_data
- clarify new initMap and loadMarkers JS functions

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686584d6342c8329a16fff11d5d947de