### PR TITLE
Use custom image assets for map pins

### DIFF
--- a/app/static/assets/marker-pin-blue.svg
+++ b/app/static/assets/marker-pin-blue.svg
@@ -1,0 +1,4 @@
+<svg width="36" height="48" viewBox="0 0 36 48" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 1C9.71573 1 3 7.71573 3 16C3 25.568 14.4 37.536 17.1188 40.5039C17.6048 41.0401 18.3952 41.0401 18.8812 40.5039C21.6 37.536 33 25.568 33 16C33 7.71573 26.2843 1 18 1Z" fill="#2563EB" stroke="#ffffff" stroke-width="2"/>
+  <circle cx="18" cy="17" r="7" fill="#F8FAFC" fill-opacity="0.9"/>
+</svg>

--- a/app/static/assets/marker-pin-gray.svg
+++ b/app/static/assets/marker-pin-gray.svg
@@ -1,0 +1,4 @@
+<svg width="36" height="48" viewBox="0 0 36 48" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 1C9.71573 1 3 7.71573 3 16C3 25.568 14.4 37.536 17.1188 40.5039C17.6048 41.0401 18.3952 41.0401 18.8812 40.5039C21.6 37.536 33 25.568 33 16C33 7.71573 26.2843 1 18 1Z" fill="#6B7280" stroke="#ffffff" stroke-width="2"/>
+  <circle cx="18" cy="17" r="7" fill="#F3F4F6" fill-opacity="0.95"/>
+</svg>

--- a/app/static/assets/marker-pin-orange.svg
+++ b/app/static/assets/marker-pin-orange.svg
@@ -1,0 +1,4 @@
+<svg width="36" height="48" viewBox="0 0 36 48" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 1C9.71573 1 3 7.71573 3 16C3 25.568 14.4 37.536 17.1188 40.5039C17.6048 41.0401 18.3952 41.0401 18.8812 40.5039C21.6 37.536 33 25.568 33 16C33 7.71573 26.2843 1 18 1Z" fill="#F97316" stroke="#ffffff" stroke-width="2"/>
+  <circle cx="18" cy="17" r="7" fill="#FFF7ED" fill-opacity="0.95"/>
+</svg>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -24,8 +24,12 @@
                             width: 100vw; 
                             height: 100vh; }
 
-        #map {  width: 100%; 
+        #map {  width: 100%;
                 height: 100%; }
+
+        .leaflet-marker-icon.marker-pin-icon {
+            filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.25));
+        }
 
         .menu-container {   position: absolute; 
                             top: 0; 
@@ -344,6 +348,14 @@ const SOURCE_TYPE_LABELS = {
     manual: 'Manual Entry',
 };
 
+const MARKER_ICON_PATHS = {
+    google_timeline: "{{ url_for('static', filename='assets/marker-pin-blue.svg') }}",
+    manual: "{{ url_for('static', filename='assets/marker-pin-orange.svg') }}",
+    default: "{{ url_for('static', filename='assets/marker-pin-gray.svg') }}",
+};
+
+const markerIconCache = new Map();
+
 function getSourceTypeLabel(type) {
     if (!type) { return ''; }
     if (Object.prototype.hasOwnProperty.call(SOURCE_TYPE_LABELS, type)) {
@@ -352,6 +364,24 @@ function getSourceTypeLabel(type) {
     return type
         .replace(/_/g, ' ')
         .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function getMarkerIcon(sourceType) {
+    const iconUrl = MARKER_ICON_PATHS[sourceType] || MARKER_ICON_PATHS.default;
+    if (markerIconCache.has(iconUrl)) {
+        return markerIconCache.get(iconUrl);
+    }
+    const icon = L.icon({
+        className: 'marker-pin-icon',
+        iconUrl,
+        iconRetinaUrl: iconUrl,
+        iconSize: [36, 48],
+        iconAnchor: [18, 44],
+        popupAnchor: [0, -40],
+    });
+
+    markerIconCache.set(iconUrl, icon);
+    return icon;
 }
 
 function showLoading() { document.getElementById('loading').style.display = 'flex'; }
@@ -399,10 +429,21 @@ async function loadMarkers() {
         const markers = await response.json();
         // Add a Leaflet marker for each item returned
         markers.forEach(m => {
-            const popup = `<div><strong>Place Name:</strong> ${m.place}<br>` +
-                          `<strong>Date Visited:</strong> ${m.date}<br>` +
-                          `<strong>Coordinates:</strong> ${m.lat.toFixed(4)}, ${m.lng.toFixed(4)}</div>`;
-            L.marker([m.lat, m.lng]).bindPopup(popup).addTo(markerCluster);
+            const sourceLabel = getSourceTypeLabel(m.source_type);
+            const popup = [
+                `<div><strong>Place Name:</strong> ${m.place}<br>`,
+                sourceLabel ? `<strong>Source:</strong> ${sourceLabel}<br>` : '',
+                `<strong>Date Visited:</strong> ${m.date}<br>`,
+                `<strong>Coordinates:</strong> ${m.lat.toFixed(4)}, ${m.lng.toFixed(4)}</div>`
+            ].join('');
+
+            const marker = L.marker([m.lat, m.lng], {
+                icon: getMarkerIcon(m.source_type),
+                title: m.place || '',
+                riseOnHover: true,
+            });
+
+            marker.bindPopup(popup).addTo(markerCluster);
         });
         // Done loading
         hideLoading();


### PR DESCRIPTION
## Summary
- style Leaflet markers with SVG pin images per source type so points stand out on the map
- cache L.icon instances keyed by icon URL to keep marker rendering fast
- include source labels in marker popups while keeping clustering logic the same

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6208450c8329a790ff066b8b298b