### PR TITLE
Add date range filtering for map markers

### DIFF
--- a/app/map_utils.py
+++ b/app/map_utils.py
@@ -208,3 +208,48 @@ def dataframe_to_markers(df: pd.DataFrame) -> list[dict]:
 
     # The frontend expects a list of marker dictionaries
     return markers
+
+
+def filter_dataframe_by_date_range(
+    df: pd.DataFrame,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> pd.DataFrame:
+    """Return rows that fall within the provided ``start_date``/``end_date`` range.
+
+    Parameters
+    ----------
+    df:
+        Timeline data to filter.
+    start_date, end_date:
+        Optional ISO formatted date strings (``YYYY-MM-DD``).  When omitted,
+        the corresponding bound is ignored.
+    """
+
+    if df is None or df.empty:
+        return df
+
+    if "Start Date" not in df.columns:
+        return df
+
+    # Normalise empty strings to ``None`` so ``pd.to_datetime`` handles them.
+    start_date = start_date or None
+    end_date = end_date or None
+
+    if start_date is None and end_date is None:
+        return df
+
+    dates = pd.to_datetime(df["Start Date"], errors="coerce")
+    mask = pd.Series(True, index=df.index)
+
+    if start_date is not None:
+        start = pd.to_datetime(start_date, errors="coerce")
+        if pd.notna(start):
+            mask &= dates >= start
+
+    if end_date is not None:
+        end = pd.to_datetime(end_date, errors="coerce")
+        if pd.notna(end):
+            mask &= dates <= end
+
+    return df.loc[mask]

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -153,9 +153,10 @@
         .overlay-button:active {    transform: translateY(0); 
                                     box-shadow: 4px 5px 0px 0px rgba(0, 0, 0, 0.15); }
 
-        .checkbox-group {               display: flex; 
-                                        flex-direction: column; 
-                                        gap: 4px; }
+        .checkbox-group {               display: flex;
+                                        flex-direction: column;
+                                        gap: 4px;
+                                        align-self: stretch; }
 
         .checkbox-group label {         display: flex; 
                                         align-items: center; 
@@ -163,11 +164,47 @@
                                         font-size: 14px; 
                                         justify-content: space-between; }
 
-        .checkbox-group label span {    flex: 1; 
-                                        min-width: 0; 
-                                        text-align: right;}
+        .checkbox-group label span {    flex: 1;
+                                        min-width: 0;
+                                        text-align: right; }
 
         .checkbox-group label input { flex-shrink: 0; }
+
+        .date-filter-group {            display: flex;
+                                        flex-direction: column;
+                                        gap: 8px;
+                                        align-self: stretch; }
+
+        .date-filter-group label {      display: flex;
+                                        align-items: center;
+                                        gap: 8px;
+                                        font-size: 14px;
+                                        justify-content: space-between; }
+
+        .date-filter-group label span { flex: 1;
+                                        text-align: right; }
+
+        .date-filter-group input {      border: 1px solid #ccc;
+                                        border-radius: 8px;
+                                        padding: 6px 10px;
+                                        font-size: 14px;
+                                        font-family: inherit; }
+
+        .date-filter-actions {          display: flex;
+                                        justify-content: flex-end; }
+
+        .date-filter-clear {            background: none;
+                                        border: none;
+                                        color: #0078d4;
+                                        font-size: 13px;
+                                        font-weight: 600;
+                                        cursor: pointer;
+                                        padding: 0; }
+
+        .date-filter-clear:hover {      text-decoration: underline; }
+
+        .date-filter-clear:focus {      outline: 2px solid rgba(0,120,212,0.6);
+                                        outline-offset: 2px; }
 
         #status {   position: absolute; 
                     bottom: 20px; 
@@ -289,6 +326,20 @@
             <button class="overlay-button" onclick="refreshMap()">Refresh Map</button>
             <h2 class="overlay-section-title" id="filtersTitle">Filters</h2>
             <div id="sourceTypeFilters" class="checkbox-group" role="group" aria-labelledby="filtersTitle"></div>
+            <h2 class="overlay-section-title" id="dateFiltersTitle">Date Range</h2>
+            <div class="date-filter-group" id="dateFilters" role="group" aria-labelledby="dateFiltersTitle">
+                <label for="filterStartDate">
+                    <span>Start Date</span>
+                    <input type="date" id="filterStartDate" name="filterStartDate">
+                </label>
+                <label for="filterEndDate">
+                    <span>End Date</span>
+                    <input type="date" id="filterEndDate" name="filterEndDate">
+                </label>
+                <div class="date-filter-actions">
+                    <button type="button" class="date-filter-clear" id="clearDateFilters">Clear Dates</button>
+                </div>
+            </div>
         </div>
     </div>
     <div id="status"></div>
@@ -411,18 +462,34 @@ function initMap() {
 async function loadMarkers() {
     // Show a loading overlay while fetching marker data
     showLoading();
+    const startDateInput = document.getElementById('filterStartDate');
+    const endDateInput = document.getElementById('filterEndDate');
+    const startDate = startDateInput ? startDateInput.value : '';
+    const endDate = endDateInput ? endDateInput.value : '';
+
+    if (startDate && endDate && startDate > endDate) {
+        hideLoading();
+        showStatus('Start date must be on or before end date.', true);
+        return;
+    }
+
     // Remove any markers currently displayed
     markerCluster.clearLayers();
     // Collect the values of all checked source type filters
     const checked = Array.from(
         document.querySelectorAll('#sourceTypeFilters input:checked')
     ).map(cb => cb.value);
+
+    const payload = { source_types: checked };
+    if (startDate) { payload.start_date = startDate; }
+    if (endDate) { payload.end_date = endDate; }
+
     try {
         // Request the marker list from the server, filtering by source type
         const response = await fetch('/api/map_data', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ source_types: checked })
+            body: JSON.stringify(payload)
         });
         // Parse the JSON response
         const markers = await response.json();
@@ -699,6 +766,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     } catch(err) {
         console.error('Failed to load source types', err);
+    }
+    const startDateInput = document.getElementById('filterStartDate');
+    const endDateInput = document.getElementById('filterEndDate');
+    const clearDateButton = document.getElementById('clearDateFilters');
+
+    if (startDateInput) { startDateInput.addEventListener('change', loadMarkers); }
+    if (endDateInput) { endDateInput.addEventListener('change', loadMarkers); }
+    if (clearDateButton) {
+        clearDateButton.addEventListener('click', () => {
+            if (startDateInput) { startDateInput.value = ''; }
+            if (endDateInput) { endDateInput.value = ''; }
+            loadMarkers();
+        });
     }
     initMap();
     const menu = document.querySelector('.menu-container');


### PR DESCRIPTION
## Summary
- add a reusable helper that filters timeline data by an optional date range
- extend the map data API to honor start/end date filters from the client
- expose date range controls in the UI and propagate them through marker loading

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd7323e3ac8329bc271bf2a15288e7