### PR TITLE
Add confirmations before destructive actions and backup on map clear

### DIFF
--- a/app/data_cache.py
+++ b/app/data_cache.py
@@ -1,8 +1,11 @@
 import os
+from datetime import datetime
+
 import pandas as pd
 
 # Path to the master timeline CSV
 CSV_PATH = os.path.join('data', 'master_timeline_data.csv')
+BACKUP_TEMPLATE = os.path.join('data', 'master_timeline_data_backup_{timestamp}.csv')
 
 # Cached pandas DataFrame
 timeline_df = None
@@ -54,4 +57,28 @@ def save_timeline_data():
         print(f"Saved {len(timeline_df)} rows to {CSV_PATH}")
     except Exception as exc:
         print(f"Failed to save {CSV_PATH}: {exc}")
+
+
+def backup_timeline_data():
+    """Create a timestamped backup of the current ``timeline_df``.
+
+    Returns the path to the backup file if a backup was created.
+    """
+
+    global timeline_df
+
+    if timeline_df is None or timeline_df.empty:
+        print("No timeline data to backup.")
+        return None
+
+    ensure_archived_column()
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    backup_path = BACKUP_TEMPLATE.format(timestamp=timestamp)
+
+    os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+
+    timeline_df.to_csv(backup_path, index=False)
+    print(f"Created backup with {len(timeline_df)} rows at {backup_path}")
+    return backup_path
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -69,9 +69,26 @@ def api_update_timeline():
 def api_clear():
     """Clear all timeline data and reset the map state."""
 
+    df = data_cache.timeline_df
+    backup_path = None
+
+    if df is not None and not df.empty:
+        try:
+            backup_path = data_cache.backup_timeline_data()
+        except Exception as exc:
+            return jsonify({
+                'status': 'error',
+                'message': f'Failed to create backup before clearing data: {exc}'
+            }), 500
+
     data_cache.timeline_df = pd.DataFrame()
     data_cache.save_timeline_data()
-    return jsonify({'status': 'success', 'message': 'All timeline data cleared successfully.'})
+
+    message = 'All timeline data cleared successfully.'
+    if backup_path:
+        message += f' Backup saved to {backup_path}.'
+
+    return jsonify({'status': 'success', 'message': message})
 
 
 @main.route('/api/add_point', methods=['POST'])

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -745,6 +745,11 @@ async function updateMap() {
 }
 
 async function clearMap() {
+    const confirmClear = window.confirm(
+        'Clearing the map will remove all data permanently. This action cannot be undone. Do you want to continue?'
+    );
+    if (!confirmClear) { return; }
+
     showLoading();
     try {
         const response = await fetch('/api/clear', { method: 'POST' });
@@ -1160,6 +1165,11 @@ async function deleteMarker(markerId, markerInstance, triggerButton) {
         showStatus('This data point cannot be deleted.', true);
         return;
     }
+
+    const confirmDelete = window.confirm(
+        'Deleting this data point is irreversible. Do you want to continue?'
+    );
+    if (!confirmDelete) { return; }
 
     if (triggerButton) { triggerButton.disabled = true; }
     showLoading();


### PR DESCRIPTION
## Summary
- prompt the user to confirm before deleting a marker or clearing the map, emphasizing the irreversible nature of the action
- create a timestamped backup of the timeline CSV before clearing the map and surface the backup location in the API response

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd8f1cb8dc8329bbc90e1acb75adaa