### PR TITLE
Improve trip sorting defaults and expand trips sidebar

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -160,6 +160,10 @@ button, input, select { font-family: inherit; }
                     max-height: min(96vh, 768px);
                     overflow-y: auto; }
 
+.overlay-controls[data-active-panel="menuPanelTrips"] {
+    max-height: min(96vh, 960px);
+}
+
 .overlay-tabs-wrapper {  display: flex;
                         align-items: center;
                         gap: 6px;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -90,8 +90,8 @@ const TRIP_LOCATION_SORT_FIELD_NAME = 'name';
 const tripListState = {
     trips: [],
     searchTerm: '',
-    sortField: TRIP_SORT_FIELD_NAME,
-    sortDirection: TRIP_SORT_DIRECTION_ASC,
+    sortField: TRIP_SORT_FIELD_DATE,
+    sortDirection: TRIP_SORT_DIRECTION_DESC,
     initialised: false,
 };
 
@@ -3998,6 +3998,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const activateTab = (nextTab) => {
             if (!nextTab) { return; }
+            const activePanel = findPanelForTab(nextTab);
             tabs.forEach((tab) => {
                 const isActive = tab === nextTab;
                 tab.setAttribute('aria-selected', String(isActive));
@@ -4007,6 +4008,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     panel.hidden = !isActive;
                 }
             });
+            if (activePanel) {
+                menuControls.dataset.activePanel = activePanel.id;
+            } else {
+                delete menuControls.dataset.activePanel;
+            }
         };
 
         const focusTab = (tab) => {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -72,11 +72,11 @@
                                     <span class="trip-sort-label">Sort by</span>
                                     <select id="tripSortField" name="tripSortField">
                                         <option value="name">Name</option>
-                                        <option value="latest_location_date">Date</option>
+                                        <option value="latest_location_date" selected>Date</option>
                                     </select>
                                 </label>
-                                <button type="button" class="trip-sort-direction" id="tripSortDirection" aria-label="Sort descending">
-                                    Ascending
+                                <button type="button" class="trip-sort-direction" id="tripSortDirection" aria-label="Sort ascending">
+                                    Descending
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- default the trips panel to sort journeys by their latest date value in descending order so the most recent appear first
- update the sort controls so the Date field and descending direction are preselected in the UI
- let the trips sidebar expand taller by tagging the active panel for targeted styling

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d1c6411358832999b2d123a905d984