### PR TITLE
Close trip detail view when pressing Escape

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -4272,6 +4272,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (aliasModalElement && aliasModalElement.classList.contains('open')) { return; }
         const archivedModalElement = document.getElementById('archivedPointsModal');
         if (archivedModalElement && archivedModalElement.classList.contains('open')) { return; }
+
+        if (tripDetailState && tripDetailState.selectedTripId !== null) {
+            event.preventDefault();
+            closeTripDetail();
+            if (typeof event.stopImmediatePropagation === 'function') {
+                event.stopImmediatePropagation();
+            }
+            if (typeof event.stopPropagation === 'function') {
+                event.stopPropagation();
+            }
+            return;
+        }
+
         const menu = document.querySelector('.menu-container');
         if (menu && menu.classList.contains('open')) {
             event.preventDefault();


### PR DESCRIPTION
## Summary
- close the trip detail panel when Escape is pressed so the selected trip exits without shutting the menu
- stop further Escape handling once the detail view closes to avoid conflicting shortcuts

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1e4670e8883299426d88773f351ce