### PR TITLE
Update trip marker styling

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -21,43 +21,47 @@ button, input, select { font-family: inherit; }
 
 .leaflet-marker-icon.trip-marker-icon {
     position: relative;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.95), rgba(255, 125, 0, 0.95));
-    border: 4px solid rgba(255, 255, 255, 0.9);
-    box-shadow: 0 12px 28px rgba(255, 107, 0, 0.45);
-    overflow: hidden;
-    transform-origin: center;
+    width: 36px;
+    height: 48px;
+    transform-origin: center bottom;
     transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.leaflet-marker-icon.trip-marker-icon::after {
-    content: '';
-    position: absolute;
-    inset: 8px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #ff7a18, #ffb347);
-    box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.55);
+    -webkit-clip-path: path('M18 0C8.6 0 0 8.6 0 18c0 12.2 13.6 24.6 16.4 27.6c0.9 0.9 2.3 0.9 3.2 0C22.4 42.6 36 30.2 36 18C36 8.6 27.4 0 18 0Z');
+    clip-path: path('M18 0C8.6 0 0 8.6 0 18c0 12.2 13.6 24.6 16.4 27.6c0.9 0.9 2.3 0.9 3.2 0C22.4 42.6 36 30.2 36 18C36 8.6 27.4 0 18 0Z');
+    background: linear-gradient(145deg, #f87171, #b91c1c);
+    box-shadow:
+        0 0 0 2px rgba(255, 255, 255, 0.95),
+        0 14px 26px rgba(190, 24, 93, 0.45);
+    overflow: visible;
 }
 
 .leaflet-marker-icon.trip-marker-icon::before {
     content: '';
     position: absolute;
-    bottom: -12px;
+    inset: 0;
+    -webkit-clip-path: inherit;
+    clip-path: inherit;
+    background: linear-gradient(160deg, rgba(248, 113, 113, 0.95), rgba(185, 28, 28, 0.95));
+}
+
+.leaflet-marker-icon.trip-marker-icon::after {
+    content: '';
+    position: absolute;
+    top: 12px;
     left: 50%;
-    transform: translateX(-50%);
     width: 18px;
     height: 18px;
-    background: rgba(255, 125, 0, 0.65);
+    transform: translateX(-50%);
     border-radius: 50%;
-    filter: blur(8px);
+    background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.95), rgba(254, 202, 202, 0.9));
+    box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.55);
 }
 
 .leaflet-marker-icon.trip-marker-icon:hover,
 .leaflet-marker-icon.trip-marker-icon.leaflet-interactive:focus {
-    transform: scale(1.06);
-    box-shadow: 0 16px 34px rgba(255, 107, 0, 0.55);
+    transform: translateY(-2px) scale(1.05);
+    box-shadow:
+        0 0 0 2px rgba(255, 255, 255, 0.95),
+        0 18px 34px rgba(190, 24, 93, 0.55);
 }
 
 .leaflet-tooltip.trip-marker-tooltip {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -3345,9 +3345,9 @@ function getTripHighlightIcon() {
     if (tripMarkerIconInstance) { return tripMarkerIconInstance; }
     tripMarkerIconInstance = L.divIcon({
         className: 'trip-marker-icon',
-        iconSize: [32, 32],
-        iconAnchor: [24, 24],
-        popupAnchor: [0, -28],
+        iconSize: [36, 48],
+        iconAnchor: [18, 44],
+        popupAnchor: [0, -40],
     });
     return tripMarkerIconInstance;
 }


### PR DESCRIPTION
## Summary
- restyle trip highlight markers to use a red pin silhouette similar to standard map markers
- update the trip marker icon sizing and anchors to match the new pin proportions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4adbde96c8329853d5fe63b48ea06