### PR TITLE
Gate trip metadata editing behind explicit edit mode

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -425,10 +425,45 @@ button, input, select { font-family: inherit; }
 .trip-profile-actions {
     display: flex;
     justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 
 .trip-profile-actions[hidden] {
     display: none;
+}
+
+.trip-detail-edit {
+    border: none;
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(255,255,255,0.18);
+    color: #1f2937;
+    cursor: pointer;
+    transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    box-shadow: inset 0 0 0 1px rgba(17,24,39,0.12);
+}
+
+.trip-detail-edit:hover:not(:disabled) {
+    background: rgba(255,255,255,0.28);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(17, 24, 39, 0.12);
+}
+
+.trip-detail-edit:focus-visible {
+    outline: 2px solid rgba(17, 24, 39, 0.7);
+    outline-offset: 2px;
+}
+
+.trip-detail-edit:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
 }
 
 .trip-profile-hero .trip-detail-delete {
@@ -441,10 +476,68 @@ button, input, select { font-family: inherit; }
     background: rgba(254,202,202,0.98);
 }
 
+.trip-profile-description-display {
+    border: 1px solid rgba(209,213,219,0.9);
+    border-radius: 16px;
+    padding: 14px 16px;
+    font-size: 14px;
+    line-height: 1.6;
+    background: rgba(255,255,255,0.92);
+    color: #1f2937;
+    min-height: 120px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.trip-profile-description-display.trip-profile-description-empty {
+    color: #6b7280;
+    font-style: italic;
+}
+
+.trip-profile-updated-readonly {
+    margin-top: 8px;
+}
+
+.trip-profile-panel-editing .trip-profile-updated-readonly {
+    display: none;
+}
+
 .trip-profile-description {
     display: flex;
     flex-direction: column;
     gap: 10px;
+}
+
+.trip-profile-name-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.trip-profile-name-field[hidden] {
+    display: none;
+}
+
+.trip-profile-name-field input {
+    border: 1px solid rgba(209,213,219,0.9);
+    border-radius: 14px;
+    padding: 10px 14px;
+    font-size: 14px;
+    line-height: 1.4;
+    background: rgba(249,250,251,0.92);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.trip-profile-name-field input:focus {
+    outline: none;
+    border-color: #111827;
+    box-shadow: 0 0 0 3px rgba(17,24,39,0.15);
+}
+
+.trip-profile-name-field input:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
 }
 
 .trip-profile-panel form.is-saving {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -55,6 +55,8 @@ let tripDescriptionStatusElement = null;
 let tripDescriptionTitleElement = null;
 let tripDescriptionUpdatedElement = null;
 let tripDescriptionUpdatedTimeElement = null;
+let tripDescriptionUpdatedReadOnlyElement = null;
+let tripDescriptionUpdatedReadOnlyTimeElement = null;
 let tripDescriptionSaveButton = null;
 let tripDescriptionCancelButton = null;
 let tripDescriptionCloseButton = null;
@@ -84,7 +86,11 @@ let tripDetailSubtitleElement = null;
 let tripDetailCountElement = null;
 let tripDetailUpdatedElement = null;
 let tripDetailActionsElement = null;
+let tripDetailEditButton = null;
 let tripDetailDeleteButton = null;
+let tripNameInputContainer = null;
+let tripNameInputElement = null;
+let tripDescriptionDisplayElement = null;
 let tripLocationSearchInput = null;
 let tripLocationSortFieldSelect = null;
 let tripLocationSortDirectionButton = null;
@@ -130,8 +136,14 @@ const tripDescriptionState = {
     requestId: 0,
     isSaving: false,
     isDirty: false,
+    isNameDirty: false,
     lastAppliedDescription: '',
+    lastAppliedName: '',
     triggerElement: null,
+};
+
+const tripProfileEditState = {
+    active: false,
 };
 
 const manageModeState = {
@@ -1655,6 +1667,7 @@ function initTripDetailPanel() {
     tripDetailCountElement = document.getElementById('tripDetailCount');
     tripDetailUpdatedElement = document.getElementById('tripDetailUpdated');
     tripDetailActionsElement = document.getElementById('tripDetailActions');
+    tripDetailEditButton = document.getElementById('tripDetailEdit');
     tripDetailDeleteButton = document.getElementById('tripDetailDelete');
     tripLocationSearchInput = document.getElementById('tripLocationSearchInput');
     tripLocationSortFieldSelect = document.getElementById('tripLocationSortField');
@@ -1679,9 +1692,17 @@ function initTripDetailPanel() {
         tripDescriptionCloseButton = tripDetailBackButton;
     }
 
+    if (tripDetailEditButton && !tripDetailEditButton.dataset.initialised) {
+        tripDetailEditButton.addEventListener('click', handleTripDetailEditClick);
+        tripDetailEditButton.disabled = true;
+        tripDetailEditButton.dataset.initialised = 'true';
+        tripDetailEditButton.setAttribute('aria-pressed', 'false');
+    }
+
     if (tripDetailDeleteButton) {
         tripDetailDeleteButton.addEventListener('click', handleTripDetailDeleteClick);
         tripDetailDeleteButton.disabled = true;
+        tripDetailDeleteButton.hidden = true;
     }
 
     if (tripDetailActionsElement) {
@@ -1817,14 +1838,17 @@ async function handleTripDetailDeleteClick(event) {
 }
 
 function updateTripDescriptionSaveButtonState() {
-    const disableSave = !tripDescriptionState.tripId
+    const hasChanges = Boolean(tripDescriptionState.isDirty || tripDescriptionState.isNameDirty);
+    const disableSave = !tripProfileEditState.active
+        || !tripDescriptionState.tripId
         || tripDescriptionState.isSaving
-        || !tripDescriptionState.isDirty;
+        || !hasChanges;
     if (tripDescriptionSaveButton) {
         tripDescriptionSaveButton.disabled = disableSave;
     }
     if (tripDescriptionCancelButton) {
-        tripDescriptionCancelButton.disabled = Boolean(tripDescriptionState.isSaving);
+        tripDescriptionCancelButton.disabled = !tripProfileEditState.active
+            || Boolean(tripDescriptionState.isSaving);
     }
     if (tripDescriptionCloseButton) {
         tripDescriptionCloseButton.disabled = Boolean(tripDescriptionState.isSaving);
@@ -1845,40 +1869,157 @@ function showTripDescriptionStatus(message, isError = false) {
     }
 }
 
+function updateTripDescriptionDisplay(description) {
+    initTripProfilePanel();
+    if (!tripDescriptionDisplayElement) { return; }
+
+    const value = typeof description === 'string'
+        ? description
+        : tripDescriptionState.lastAppliedDescription || '';
+    const trimmed = value.trim();
+
+    if (trimmed) {
+        tripDescriptionDisplayElement.textContent = value;
+        tripDescriptionDisplayElement.classList.remove('trip-profile-description-empty');
+    } else {
+        tripDescriptionDisplayElement.textContent = 'No description has been added yet.';
+        tripDescriptionDisplayElement.classList.add('trip-profile-description-empty');
+    }
+}
+
+function applyTripProfileEditMode() {
+    initTripProfilePanel();
+
+    const isEditing = Boolean(tripProfileEditState.active);
+
+    if (tripProfilePanelElement) {
+        tripProfilePanelElement.classList.toggle('trip-profile-panel-editing', isEditing);
+    }
+    if (tripDescriptionForm) {
+        tripDescriptionForm.hidden = !isEditing;
+    }
+    if (tripDescriptionDisplayElement) {
+        tripDescriptionDisplayElement.hidden = isEditing;
+    }
+    if (tripNameInputContainer) {
+        tripNameInputContainer.hidden = !isEditing;
+    }
+    if (tripDetailEditButton) {
+        tripDetailEditButton.disabled = isEditing || Boolean(tripDescriptionState.isSaving);
+        tripDetailEditButton.setAttribute('aria-pressed', isEditing ? 'true' : 'false');
+    }
+    if (tripNameInputElement) {
+        tripNameInputElement.disabled = Boolean(tripDescriptionState.isSaving);
+    }
+    if (tripDescriptionField) {
+        tripDescriptionField.disabled = Boolean(tripDescriptionState.isSaving);
+    }
+
+    updateTripDetailActions();
+    updateTripDescriptionSaveButtonState();
+}
+
+function enterTripProfileEditMode() {
+    initTripProfilePanel();
+    if (tripProfileEditState.active) { return; }
+
+    tripProfileEditState.active = true;
+
+    const nameValue = tripDescriptionState.lastAppliedName || '';
+    if (tripNameInputElement) {
+        tripNameInputElement.value = nameValue;
+    }
+
+    const descriptionValue = tripDescriptionState.lastAppliedDescription || '';
+    if (tripDescriptionField) {
+        tripDescriptionField.value = descriptionValue;
+    }
+
+    tripDescriptionState.isDirty = false;
+    tripDescriptionState.isNameDirty = false;
+
+    showTripDescriptionStatus('');
+    applyTripProfileEditMode();
+
+    const focusTarget = tripNameInputElement || tripDescriptionField || null;
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+        try {
+            focusTarget.focus({ preventScroll: true });
+        } catch (error) {
+            focusTarget.focus();
+        }
+    }
+}
+
+function exitTripProfileEditMode(options = {}) {
+    initTripProfilePanel();
+
+    const { restoreFocus = false, focusTarget = null } = options || {};
+
+    if (!tripProfileEditState.active && !options.force) {
+        return;
+    }
+
+    tripProfileEditState.active = false;
+    tripDescriptionState.isDirty = false;
+    tripDescriptionState.isNameDirty = false;
+
+    if (tripNameInputElement) {
+        tripNameInputElement.value = tripDescriptionState.lastAppliedName || '';
+    }
+    if (tripDescriptionField) {
+        tripDescriptionField.value = tripDescriptionState.lastAppliedDescription || '';
+    }
+
+    applyTripProfileEditMode();
+    updateTripDescriptionDisplay();
+
+    const target = focusTarget || (restoreFocus ? tripDetailEditButton : null);
+    if (target && typeof target.focus === 'function') {
+        try {
+            target.focus({ preventScroll: true });
+        } catch (error) {
+            target.focus();
+        }
+    }
+}
+
 function setTripDescriptionSaving(isSaving) {
     const saving = Boolean(isSaving);
     tripDescriptionState.isSaving = saving;
     if (tripDescriptionForm) {
         tripDescriptionForm.classList.toggle('is-saving', saving);
     }
+    if (tripNameInputElement) {
+        tripNameInputElement.disabled = saving;
+    }
     if (tripDescriptionField) {
         tripDescriptionField.disabled = saving;
     }
+    if (tripDetailEditButton) {
+        tripDetailEditButton.disabled = saving || tripProfileEditState.active;
+    }
+    if (tripDetailDeleteButton) {
+        tripDetailDeleteButton.disabled = saving || !tripProfileEditState.active;
+    }
     updateTripDescriptionSaveButtonState();
+}
+
+function handleTripDetailEditClick(event) {
+    if (event) { event.preventDefault(); }
+    if (tripDescriptionState.isSaving) { return; }
+    if (!tripDetailState.trip || !tripDetailState.trip.id) { return; }
+    enterTripProfileEditMode();
 }
 
 function handleTripDescriptionCancel(event) {
     if (event) { event.preventDefault(); }
     initTripProfilePanel();
 
-    const lastValue = tripDescriptionState.lastAppliedDescription || '';
-    const wasDirty = Boolean(tripDescriptionState.isDirty);
+    const wasDirty = Boolean(tripDescriptionState.isDirty || tripDescriptionState.isNameDirty);
+    exitTripProfileEditMode({ restoreFocus: true });
 
-    if (tripDescriptionField) {
-        tripDescriptionField.value = lastValue;
-        try {
-            tripDescriptionField.focus({ preventScroll: true });
-        } catch (error) {
-            tripDescriptionField.focus();
-        }
-    }
-
-    tripDescriptionState.isDirty = false;
-    updateTripDescriptionSaveButtonState();
-
-    const statusMessage = wasDirty
-        ? (lastValue ? 'Reverted to last saved description.' : 'Cleared description changes.')
-        : '';
+    const statusMessage = wasDirty ? 'Discarded unsaved changes.' : '';
     showTripDescriptionStatus(statusMessage);
 }
 
@@ -1890,6 +2031,15 @@ function populateTripProfilePanel(trip, options = {}) {
         tripDescriptionTitleElement.textContent = name;
     }
 
+    tripDescriptionState.lastAppliedName = name;
+    if (tripNameInputElement) {
+        const shouldUpdateNameField = !preserveDirty || !tripDescriptionState.isNameDirty;
+        if (shouldUpdateNameField) {
+            tripNameInputElement.value = name;
+            tripDescriptionState.isNameDirty = false;
+        }
+    }
+
     const description = trip && typeof trip.description === 'string'
         ? trip.description
         : '';
@@ -1897,8 +2047,8 @@ function populateTripProfilePanel(trip, options = {}) {
         ? (trip.updated_at || trip.latest_location_date || trip.created_at || '')
         : '';
 
+    const label = formatTripUpdatedTimestamp(timestamp);
     if (tripDescriptionUpdatedElement && tripDescriptionUpdatedTimeElement) {
-        const label = formatTripUpdatedTimestamp(timestamp);
         if (label) {
             tripDescriptionUpdatedElement.hidden = false;
             tripDescriptionUpdatedTimeElement.textContent = label;
@@ -1907,6 +2057,17 @@ function populateTripProfilePanel(trip, options = {}) {
             tripDescriptionUpdatedElement.hidden = true;
             tripDescriptionUpdatedTimeElement.textContent = '';
             tripDescriptionUpdatedTimeElement.removeAttribute('dateTime');
+        }
+    }
+    if (tripDescriptionUpdatedReadOnlyElement && tripDescriptionUpdatedReadOnlyTimeElement) {
+        if (label) {
+            tripDescriptionUpdatedReadOnlyElement.hidden = false;
+            tripDescriptionUpdatedReadOnlyTimeElement.textContent = label;
+            tripDescriptionUpdatedReadOnlyTimeElement.dateTime = timestamp;
+        } else {
+            tripDescriptionUpdatedReadOnlyElement.hidden = true;
+            tripDescriptionUpdatedReadOnlyTimeElement.textContent = '';
+            tripDescriptionUpdatedReadOnlyTimeElement.removeAttribute('dateTime');
         }
     }
 
@@ -1921,7 +2082,9 @@ function populateTripProfilePanel(trip, options = {}) {
         tripDescriptionState.isDirty = false;
     }
 
+    updateTripDescriptionDisplay(description);
     updateTripDescriptionSaveButtonState();
+    updateTripDetailActions();
 }
 
 async function refreshTripDescription(tripId, requestId) {
@@ -1975,17 +2138,66 @@ async function handleTripDescriptionSubmit(event) {
         return;
     }
 
-    if (!tripDescriptionField) {
-        showTripDescriptionStatus('Description field is unavailable.', true);
+    if (!tripProfileEditState.active) {
+        showTripDescriptionStatus('Press Edit to make changes.', true);
         return;
     }
 
-    if (!tripDescriptionState.isDirty) {
+    const nameField = tripNameInputElement || null;
+    const descriptionField = tripDescriptionField || null;
+
+    if (!nameField && !descriptionField) {
+        showTripDescriptionStatus('Editing controls are unavailable.', true);
+        return;
+    }
+
+    const nameChanged = Boolean(tripDescriptionState.isNameDirty);
+    const descriptionChanged = Boolean(tripDescriptionState.isDirty);
+
+    if (!nameChanged && !descriptionChanged) {
         showTripDescriptionStatus('No changes to save.');
         return;
     }
 
-    const description = tripDescriptionField.value || '';
+    const payload = {};
+    let description = '';
+
+    if (nameChanged) {
+        const rawName = nameField ? nameField.value : '';
+        const trimmedName = rawName ? rawName.trim() : '';
+        if (!trimmedName) {
+            showTripDescriptionStatus('Trip name cannot be blank.', true);
+            if (nameField && typeof nameField.focus === 'function') {
+                try {
+                    nameField.focus({ preventScroll: true });
+                } catch (error) {
+                    nameField.focus();
+                }
+            }
+            return;
+        }
+        if (trimmedName.length > MAX_TRIP_NAME_LENGTH) {
+            showTripDescriptionStatus(`Trip name must be ${MAX_TRIP_NAME_LENGTH} characters or fewer.`, true);
+            if (nameField && typeof nameField.focus === 'function') {
+                try {
+                    nameField.focus({ preventScroll: true });
+                } catch (error) {
+                    nameField.focus();
+                }
+            }
+            return;
+        }
+        payload.name = trimmedName;
+    }
+
+    if (descriptionChanged) {
+        if (!descriptionField) {
+            showTripDescriptionStatus('Description field is unavailable.', true);
+            return;
+        }
+        description = descriptionField.value || '';
+        payload.description = description;
+    }
 
     setTripDescriptionSaving(true);
     showTripDescriptionStatus('');
@@ -1994,7 +2206,7 @@ async function handleTripDescriptionSubmit(event) {
         const response = await fetch(`/api/trips/${encodeURIComponent(tripId)}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ description }),
+            body: JSON.stringify(payload),
         });
         const result = await response.json().catch(() => ({}));
 
@@ -2008,12 +2220,19 @@ async function handleTripDescriptionSubmit(event) {
             populateTripProfilePanel(updatedTrip, { preserveDirty: false });
             upsertTripInList(updatedTrip, { reloadDetail: false });
         } else {
-            tripDescriptionState.lastAppliedDescription = description;
-            if (tripDescriptionField.value === description) {
-                tripDescriptionState.isDirty = false;
+            if (typeof payload.name === 'string') {
+                tripDescriptionState.lastAppliedName = payload.name;
             }
+            if (payload.description !== undefined) {
+                tripDescriptionState.lastAppliedDescription = payload.description;
+                if (tripDescriptionField && tripDescriptionField.value === payload.description) {
+                    tripDescriptionState.isDirty = false;
+                }
+            }
+            tripDescriptionState.isNameDirty = false;
         }
 
+        exitTripProfileEditMode({ restoreFocus: true });
         showTripDescriptionStatus(result && result.message ? result.message : 'Trip updated successfully.');
     } catch (error) {
         console.error('Failed to update trip description', error);
@@ -2033,12 +2252,17 @@ function initTripProfilePanel() {
 
     tripDescriptionForm = document.getElementById('tripDescriptionForm');
     tripDescriptionField = document.getElementById('tripDescriptionInput');
+    tripDescriptionDisplayElement = document.getElementById('tripDescriptionDisplay');
     tripDescriptionStatusElement = document.getElementById('tripDescriptionStatus');
     tripDescriptionUpdatedElement = document.getElementById('tripDescriptionUpdated');
     tripDescriptionUpdatedTimeElement = document.getElementById('tripDescriptionUpdatedTime');
+    tripDescriptionUpdatedReadOnlyElement = document.getElementById('tripDescriptionUpdatedReadOnly');
+    tripDescriptionUpdatedReadOnlyTimeElement = document.getElementById('tripDescriptionUpdatedReadOnlyTime');
     tripDescriptionSaveButton = document.getElementById('tripDescriptionSave');
     tripDescriptionCancelButton = document.getElementById('tripDescriptionCancel');
     tripDescriptionCloseButton = document.getElementById('tripDetailBack');
+    tripNameInputContainer = document.getElementById('tripNameField');
+    tripNameInputElement = document.getElementById('tripNameInput');
 
     if (!tripDescriptionTitleElement) {
         if (!tripDetailState.initialised) { initTripDetailPanel(); }
@@ -2046,6 +2270,8 @@ function initTripProfilePanel() {
     }
 
     if (tripProfilePanelInitialised) {
+        applyTripProfileEditMode();
+        updateTripDescriptionDisplay();
         updateTripDescriptionSaveButtonState();
         return;
     }
@@ -2062,7 +2288,21 @@ function initTripProfilePanel() {
         tripDescriptionField.addEventListener('input', () => {
             const currentValue = tripDescriptionField.value || '';
             const lastValue = tripDescriptionState.lastAppliedDescription || '';
-            tripDescriptionState.isDirty = currentValue !== lastValue;
+            tripDescriptionState.isDirty = tripProfileEditState.active
+                && currentValue !== lastValue;
+            updateTripDescriptionSaveButtonState();
+            if (tripDescriptionStatusElement && !tripDescriptionStatusElement.hidden) {
+                showTripDescriptionStatus('');
+            }
+        });
+    }
+
+    if (tripNameInputElement) {
+        tripNameInputElement.addEventListener('input', () => {
+            const currentValue = tripNameInputElement.value ? tripNameInputElement.value.trim() : '';
+            const lastValue = tripDescriptionState.lastAppliedName ? tripDescriptionState.lastAppliedName.trim() : '';
+            tripDescriptionState.isNameDirty = tripProfileEditState.active
+                && currentValue !== lastValue;
             updateTripDescriptionSaveButtonState();
             if (tripDescriptionStatusElement && !tripDescriptionStatusElement.hidden) {
                 showTripDescriptionStatus('');
@@ -2071,6 +2311,8 @@ function initTripProfilePanel() {
     }
 
     tripProfilePanelInitialised = true;
+    applyTripProfileEditMode();
+    updateTripDescriptionDisplay();
     updateTripDescriptionSaveButtonState();
 }
 
@@ -2087,8 +2329,12 @@ function openTripProfile(tripId, options = {}) {
     tripDescriptionState.tripId = cleanedTripId;
     tripDescriptionState.isSaving = false;
     tripDescriptionState.isDirty = false;
+    tripDescriptionState.isNameDirty = false;
     tripDescriptionState.lastAppliedDescription = '';
+    tripDescriptionState.lastAppliedName = '';
     tripDescriptionState.triggerElement = triggerElement || null;
+
+    exitTripProfileEditMode({ force: true });
 
     if (tripDescriptionForm) {
         tripDescriptionForm.classList.remove('is-saving');
@@ -2097,6 +2343,17 @@ function openTripProfile(tripId, options = {}) {
 
     if (tripDescriptionField) {
         tripDescriptionField.disabled = false;
+    }
+
+    if (tripDescriptionDisplayElement) {
+        updateTripDescriptionDisplay('');
+    }
+    if (tripDescriptionUpdatedReadOnlyElement) {
+        tripDescriptionUpdatedReadOnlyElement.hidden = true;
+    }
+    if (tripDescriptionUpdatedReadOnlyTimeElement) {
+        tripDescriptionUpdatedReadOnlyTimeElement.textContent = '';
+        tripDescriptionUpdatedReadOnlyTimeElement.removeAttribute('dateTime');
     }
 
     if (tripProfilePanelElement) {
@@ -2123,8 +2380,12 @@ function closeTripProfileOverlay(options = {}) {
     tripDescriptionState.tripId = null;
     tripDescriptionState.isSaving = false;
     tripDescriptionState.isDirty = false;
+    tripDescriptionState.isNameDirty = false;
     tripDescriptionState.lastAppliedDescription = '';
+    tripDescriptionState.lastAppliedName = '';
     tripDescriptionState.triggerElement = null;
+
+    exitTripProfileEditMode({ force: true, restoreFocus: false });
 
     if (tripDescriptionForm) {
         tripDescriptionForm.classList.remove('is-saving');
@@ -2142,6 +2403,18 @@ function closeTripProfileOverlay(options = {}) {
     if (tripDescriptionUpdatedTimeElement) {
         tripDescriptionUpdatedTimeElement.textContent = '';
         tripDescriptionUpdatedTimeElement.removeAttribute('dateTime');
+    }
+
+    if (tripDescriptionUpdatedReadOnlyElement) {
+        tripDescriptionUpdatedReadOnlyElement.hidden = true;
+    }
+    if (tripDescriptionUpdatedReadOnlyTimeElement) {
+        tripDescriptionUpdatedReadOnlyTimeElement.textContent = '';
+        tripDescriptionUpdatedReadOnlyTimeElement.removeAttribute('dateTime');
+    }
+
+    if (tripDescriptionDisplayElement) {
+        updateTripDescriptionDisplay('');
     }
 
     showTripDescriptionStatus('');
@@ -2392,7 +2665,7 @@ function updateTripDetailHeader() {
 
 function updateTripDetailActions() {
     initTripDetailPanel();
-    if (!tripDetailActionsElement || !tripDetailDeleteButton) { return; }
+    if (!tripDetailActionsElement) { return; }
 
     const trip = tripDetailState.trip;
     const hasTrip = trip && trip.id;
@@ -2402,21 +2675,44 @@ function updateTripDetailActions() {
         const name = trip.name ? String(trip.name) : TRIP_NAME_FALLBACK;
         const displayName = name || TRIP_NAME_FALLBACK;
         tripDetailActionsElement.hidden = false;
-        tripDetailDeleteButton.disabled = false;
-        tripDetailDeleteButton.dataset.tripId = tripId;
-        if (displayName) {
-            tripDetailDeleteButton.setAttribute('aria-label', `Delete trip “${displayName}”`);
-            tripDetailDeleteButton.title = `Delete trip “${displayName}”`;
-        } else {
-            tripDetailDeleteButton.setAttribute('aria-label', 'Delete trip');
-            tripDetailDeleteButton.title = 'Delete trip';
+        const isSaving = Boolean(tripDescriptionState.isSaving);
+
+        if (tripDetailEditButton) {
+            const editLabel = displayName
+                ? `Edit trip “${displayName}”`
+                : 'Edit trip';
+            tripDetailEditButton.disabled = tripProfileEditState.active || isSaving;
+            tripDetailEditButton.dataset.tripId = tripId;
+            tripDetailEditButton.setAttribute('aria-label', editLabel);
+            tripDetailEditButton.title = editLabel;
+        }
+
+        if (tripDetailDeleteButton) {
+            tripDetailDeleteButton.dataset.tripId = tripId;
+            const deleteLabel = displayName
+                ? `Delete trip “${displayName}”`
+                : 'Delete trip';
+            tripDetailDeleteButton.setAttribute('aria-label', deleteLabel);
+            tripDetailDeleteButton.title = deleteLabel;
+            const canInteract = tripProfileEditState.active && !isSaving;
+            tripDetailDeleteButton.hidden = !tripProfileEditState.active;
+            tripDetailDeleteButton.disabled = !canInteract;
         }
     } else {
         tripDetailActionsElement.hidden = true;
-        tripDetailDeleteButton.disabled = true;
-        delete tripDetailDeleteButton.dataset.tripId;
-        tripDetailDeleteButton.removeAttribute('aria-label');
-        tripDetailDeleteButton.removeAttribute('title');
+        if (tripDetailEditButton) {
+            tripDetailEditButton.disabled = true;
+            delete tripDetailEditButton.dataset.tripId;
+            tripDetailEditButton.removeAttribute('aria-label');
+            tripDetailEditButton.removeAttribute('title');
+        }
+        if (tripDetailDeleteButton) {
+            tripDetailDeleteButton.hidden = true;
+            tripDetailDeleteButton.disabled = true;
+            delete tripDetailDeleteButton.dataset.tripId;
+            tripDetailDeleteButton.removeAttribute('aria-label');
+            tripDetailDeleteButton.removeAttribute('title');
+        }
     }
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -225,16 +225,25 @@
                         <p class="trip-profile-eyebrow">Trip profile</p>
                         <h2 class="trip-profile-title" id="tripDetailTitle" data-default-text="Trip details">Trip details</h2>
                         <p class="trip-profile-subtitle" id="tripDetailSubtitle" data-default-text="Review the places assigned to this journey.">Review the places assigned to this journey.</p>
+                        <div class="trip-profile-name-field" id="tripNameField" hidden>
+                            <label class="trip-profile-description-label" for="tripNameInput">Trip name</label>
+                            <input type="text" id="tripNameInput" name="name" maxlength="120" autocomplete="off" placeholder="Trip name">
+                        </div>
                         <div class="trip-profile-meta" aria-live="polite">
                             <span id="tripDetailCount" class="trip-profile-meta-entry"></span>
                             <span id="tripDetailUpdated" class="trip-profile-meta-entry" hidden></span>
                         </div>
                         <div class="trip-profile-actions" id="tripDetailActions" hidden>
+                            <button type="button" class="trip-detail-edit" id="tripDetailEdit">Edit trip</button>
                             <button type="button" class="trip-detail-delete" id="tripDetailDelete">Delete trip</button>
                         </div>
                     </div>
                 </div>
-                <form id="tripDescriptionForm" class="trip-profile-description" novalidate>
+                <div id="tripDescriptionDisplay" class="trip-profile-description-display" aria-live="polite"></div>
+                <div class="trip-profile-updated trip-profile-updated-readonly" id="tripDescriptionUpdatedReadOnly" hidden>
+                    Last updated <time id="tripDescriptionUpdatedReadOnlyTime"></time>
+                </div>
+                <form id="tripDescriptionForm" class="trip-profile-description" novalidate hidden>
                     <label class="trip-profile-description-label" for="tripDescriptionInput">Description</label>
                     <textarea id="tripDescriptionInput" name="description" rows="6" maxlength="2000" placeholder="Describe this trip"></textarea>
                     <div class="trip-profile-description-footer">


### PR DESCRIPTION
## Summary
- add an explicit edit button and read-only trip metadata layout in the profile panel
- manage trip edit state in JavaScript so name, description, and deletion are only available after entering edit mode
- style the trip profile to support the new read-only description, edit controls, and updated timestamp presentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4aff1772083298be77354bb752f6a