### PR TITLE
Add location descriptions and editing support

### DIFF
--- a/app/data_cache.py
+++ b/app/data_cache.py
@@ -37,6 +37,19 @@ def ensure_archived_column():
             lambda value: "" if pd.isna(value) else str(value)
         )
 
+    if "Description" not in timeline_df.columns:
+        timeline_df["Description"] = ""
+    else:
+        def _clean_description(value):
+            if pd.isna(value):
+                return ""
+            text = str(value)
+            return text if text.strip() else ""
+
+        timeline_df["Description"] = timeline_df["Description"].apply(
+            _clean_description
+        )
+
 def load_timeline_data():
     """Load the timeline CSV into ``timeline_df`` if present."""
     global timeline_df

--- a/app/map_utils.py
+++ b/app/map_utils.py
@@ -248,6 +248,13 @@ def dataframe_to_markers(
         else:
             alias_value = str(alias_value).strip()
 
+        description_value = row.get("Description", "")
+        if pd.isna(description_value):
+            description_value = ""
+        else:
+            description_str = str(description_value)
+            description_value = description_str if description_str.strip() else ""
+
         display_name = alias_value or place_name
 
         markers.append(
@@ -258,6 +265,7 @@ def dataframe_to_markers(
                 "place": place_name,               # Human readable place name
                 "alias": alias_value,              # Optional custom alias provided by the user
                 "display_name": display_name,      # Alias when present otherwise the place name
+                "description": description_value,  # Optional location description
                 "date": row.get("Start Date", ""),   # Date when the place was visited
                 "source_type": row.get("Source Type", ""),  # Data source category
                 "archived": archived_value,

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -962,6 +962,13 @@ button, input, select { font-family: inherit; }
                             font-size: 12px;
                             color: #4b5563; }
 
+.trip-location-description {
+    margin-top: 2px;
+    white-space: pre-wrap;
+    line-height: 1.5;
+    color: #374151;
+}
+
 .trip-location-meta-row { display: inline-flex;
                             gap: 8px;
                             justify-content: flex-end;
@@ -1413,6 +1420,13 @@ button, input, select { font-family: inherit; }
     line-height: 1.4;
 }
 
+.form-helper-counter {
+    margin-top: 4px;
+    font-size: 12px;
+    color: #6b7280;
+    text-align: right;
+}
+
 .trip-membership-list {
     display: flex;
     flex-direction: column;
@@ -1551,6 +1565,14 @@ button, input, select { font-family: inherit; }
     color: #555;
 }
 
+.archived-item-description {
+    margin-top: 6px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: #374151;
+    white-space: pre-wrap;
+}
+
 .archived-item-place-original {
     font-size: 11px;
     color: #6b7280;
@@ -1596,6 +1618,10 @@ button, input, select { font-family: inherit; }
 .marker-popup-value {
     color: #1a1a1a;
     word-break: break-word;
+}
+
+.marker-popup-value-multiline {
+    white-space: pre-wrap;
 }
 
 .marker-popup-trips {
@@ -1662,6 +1688,16 @@ button, input, select { font-family: inherit; }
 
 .marker-action-alias:hover:not(:disabled) {
     background: #d0ecd9;
+    transform: translateY(-1px);
+}
+
+.marker-action-description {
+    background: #f3f4ff;
+    color: #4338ca;
+}
+
+.marker-action-description:hover:not(:disabled) {
+    background: #e0e7ff;
     transform: translateY(-1px);
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -136,6 +136,12 @@
                     <p class="form-helper-text">Leave blank to use the place name from your timeline.</p>
                 </div>
                 <div class="form-group">
+                    <label for="manualDescription">Description (Optional)</label>
+                    <textarea id="manualDescription" name="description" rows="4" maxlength="2000" placeholder="Add notes about this location"></textarea>
+                    <p class="form-helper-text">Optional. Share details or memories about this visit.</p>
+                    <p id="manualDescriptionCharacterCount" class="form-helper-text form-helper-counter" aria-live="polite">0 / 2000 characters</p>
+                </div>
+                <div class="form-group">
                     <label for="manualDate">Date</label>
                     <input type="date" id="manualDate" name="start_date" required>
                 </div>
@@ -168,6 +174,23 @@
                 </div>
                 <div class="modal-actions">
                     <button type="button" class="modal-button secondary" id="aliasCancel">Cancel</button>
+                    <button type="submit" class="modal-button primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="descriptionModal" class="modal-overlay" aria-hidden="true" hidden>
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="descriptionModalTitle" tabindex="-1">
+            <h2 id="descriptionModalTitle">Edit Location Description</h2>
+            <form id="descriptionForm">
+                <div class="form-group">
+                    <label for="descriptionInput">Description</label>
+                    <textarea id="descriptionInput" name="description" rows="6" maxlength="2000" placeholder="Add notes about this location"></textarea>
+                    <p class="form-helper-text">Optional. Describe what made this visit memorable.</p>
+                    <p id="descriptionCharacterCount" class="form-helper-text form-helper-counter" aria-live="polite">0 / 2000 characters</p>
+                </div>
+                <div class="modal-actions">
+                    <button type="button" class="modal-button secondary" id="descriptionCancel">Cancel</button>
                     <button type="submit" class="modal-button primary">Save</button>
                 </div>
             </form>


### PR DESCRIPTION
## Summary
- add persistence and API support for optional location descriptions outside of trips
- surface location descriptions in marker popups, trip details, and archived lists with a dedicated edit modal
- extend manual point creation and UI styling to capture and display location notes with character counters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54f812d4c8329a620c5aefa544650