### PR TITLE
Reposition trip cancel button with action controls

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -469,7 +469,8 @@ button, input, select { font-family: inherit; }
     box-shadow: none;
 }
 
-.trip-detail-edit {
+.trip-detail-edit,
+.trip-detail-cancel {
     border: none;
     border-radius: 999px;
     padding: 8px 18px;
@@ -483,19 +484,21 @@ button, input, select { font-family: inherit; }
     transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     box-shadow: inset 0 0 0 1px rgba(17,24,39,0.12);
 }
-
-.trip-detail-edit:hover:not(:disabled) {
+.trip-detail-edit:hover:not(:disabled),
+.trip-detail-cancel:hover:not(:disabled) {
     background: rgba(255,255,255,0.28);
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(17, 24, 39, 0.12);
 }
 
-.trip-detail-edit:focus-visible {
+.trip-detail-edit:focus-visible,
+.trip-detail-cancel:focus-visible {
     outline: 2px solid rgba(17, 24, 39, 0.7);
     outline-offset: 2px;
 }
 
-.trip-detail-edit:disabled {
+.trip-detail-edit:disabled,
+.trip-detail-cancel:disabled {
     opacity: 0.65;
     cursor: not-allowed;
     transform: none;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -2189,6 +2189,9 @@ function applyTripProfileEditMode() {
     if (tripDescriptionSaveButton) {
         tripDescriptionSaveButton.hidden = !isEditing;
     }
+    if (tripDescriptionCancelButton) {
+        tripDescriptionCancelButton.hidden = !isEditing;
+    }
     if (tripDetailEditButton) {
         tripDetailEditButton.disabled = isEditing || Boolean(tripDescriptionState.isSaving);
         tripDetailEditButton.setAttribute('aria-pressed', isEditing ? 'true' : 'false');
@@ -3087,6 +3090,9 @@ function updateTripDetailActions() {
             tripDetailDeleteButton.hidden = !tripProfileEditState.active;
             tripDetailDeleteButton.disabled = !canInteract;
         }
+        if (tripDescriptionCancelButton) {
+            tripDescriptionCancelButton.hidden = !tripProfileEditState.active;
+        }
     } else {
         tripDetailActionsElement.hidden = true;
         if (tripDetailEditButton) {
@@ -3101,6 +3107,9 @@ function updateTripDetailActions() {
             delete tripDetailDeleteButton.dataset.tripId;
             tripDetailDeleteButton.removeAttribute('aria-label');
             tripDetailDeleteButton.removeAttribute('title');
+        }
+        if (tripDescriptionCancelButton) {
+            tripDescriptionCancelButton.hidden = true;
         }
     }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -260,6 +260,7 @@
                             <button type="button" class="trip-detail-edit" id="tripDetailEdit">Edit trip</button>
                             <button type="button" class="trip-detail-delete" id="tripDetailDelete">Delete trip</button>
                             <button type="submit" class="trip-detail-save" id="tripDescriptionSave" form="tripDescriptionForm" disabled hidden>Save</button>
+                            <button type="button" class="trip-detail-cancel" id="tripDescriptionCancel" hidden disabled>Cancel</button>
                         </div>
                     </div>
                 </div>
@@ -273,9 +274,6 @@
                     <div class="trip-profile-description-footer">
                         <div class="trip-profile-updated" id="tripDescriptionUpdated" hidden>
                             Last updated <time id="tripDescriptionUpdatedTime"></time>
-                        </div>
-                        <div class="trip-profile-description-actions">
-                            <button type="button" class="modal-button secondary" id="tripDescriptionCancel">Cancel</button>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- move the trip description cancel button into the action row so it sits with Edit/Delete/Save controls
- style the cancel control to match the existing chip-style buttons
- toggle the cancel button based on edit mode so it only appears while editing and stays hidden otherwise

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5902b0c248329b435cea7285d16c0