### PR TITLE
Add Google Photos album preview to trip profiles

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -487,6 +487,129 @@ button, input, select { font-family: inherit; }
     flex-wrap: wrap;
 }
 
+.trip-profile-album {
+    margin-top: 32px;
+}
+
+.trip-album-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.trip-album-title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.trip-album-open-link {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #2563eb;
+    text-decoration: none;
+}
+
+.trip-album-open-link:hover,
+.trip-album-open-link:focus {
+    text-decoration: underline;
+}
+
+.trip-album-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.trip-album-form.is-saving {
+    opacity: 0.75;
+}
+
+.trip-album-input-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.trip-album-form input[type="url"] {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 12px;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.trip-album-form input[type="url"]:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+    outline: none;
+}
+
+.trip-album-form input[type="url"]:disabled {
+    background: #f3f4f6;
+    color: #6b7280;
+}
+
+.trip-album-helper {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.trip-album-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.trip-album-status {
+    margin-top: 10px;
+}
+
+.trip-album-preview {
+    margin-top: 20px;
+}
+
+.trip-album-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 12px;
+}
+
+.trip-album-photo {
+    position: relative;
+    display: block;
+    border-radius: 12px;
+    overflow: hidden;
+    background: #e5e7eb;
+    aspect-ratio: 4 / 3;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.1);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.trip-album-photo:hover,
+.trip-album-photo:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
+}
+
+.trip-album-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.trip-album-empty {
+    margin-top: 16px;
+    font-size: 0.9rem;
+    color: #6b7280;
+}
+
 .trip-profile-updated {
     font-size: 12px;
     color: #6b7280;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -248,6 +248,26 @@
                     </div>
                 </form>
                 <div id="tripDescriptionStatus" class="trip-description-status" role="status" aria-live="polite" hidden></div>
+                <section class="trip-profile-album" aria-labelledby="tripAlbumLabel">
+                    <div class="trip-album-header">
+                        <h3 id="tripAlbumLabel" class="trip-album-title">Photo album</h3>
+                        <a id="tripAlbumOpenLink" class="trip-album-open-link" href="#" target="_blank" rel="noopener" hidden>Open album</a>
+                    </div>
+                    <form id="tripAlbumForm" class="trip-album-form" novalidate>
+                        <label class="trip-album-input-label" for="tripAlbumInput">Google Photos link</label>
+                        <input type="url" id="tripAlbumInput" name="album_url" placeholder="https://photos.app.goo.gl/your-album" inputmode="url" autocomplete="off">
+                        <p class="trip-album-helper">Paste a public Google Photos album link to show a preview for this trip.</p>
+                        <div class="trip-album-actions">
+                            <button type="button" class="modal-button secondary" id="tripAlbumCancel">Cancel</button>
+                            <button type="submit" class="modal-button primary" id="tripAlbumSave" disabled>Save</button>
+                        </div>
+                    </form>
+                    <div id="tripAlbumStatus" class="trip-description-status trip-album-status" role="status" aria-live="polite" hidden></div>
+                    <div id="tripAlbumPreview" class="trip-album-preview" hidden>
+                        <div id="tripAlbumPreviewGrid" class="trip-album-grid" role="list"></div>
+                    </div>
+                    <p id="tripAlbumEmpty" class="trip-album-empty">Add a Google Photos album to showcase your memories alongside the itinerary.</p>
+                </section>
                 <div class="trip-profile-controls">
                     <div class="trip-detail-controls">
                         <label class="trip-search">

--- a/app/utils/google_photos.py
+++ b/app/utils/google_photos.py
@@ -1,0 +1,127 @@
+"""Helpers for retrieving preview images from Google Photos albums."""
+
+from __future__ import annotations
+
+import socket
+from typing import Iterable, List, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+import re
+
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+)
+
+# Google Photos share pages embed direct image links hosted on ``lh3.googleusercontent``.
+# The following expression extracts those URLs without executing the remote scripts.
+IMAGE_URL_PATTERN = re.compile(r"https://lh3\.googleusercontent\.com/[^\"'<>\\\s]+")
+
+# Maximum number of photos to return when building a preview gallery.
+DEFAULT_PHOTO_LIMIT = 30
+
+# Default size parameters appended to generated preview URLs.
+FULL_SIZE_PARAMETERS = "w2048-h1536-no"
+THUMBNAIL_PARAMETERS = "w400-h400-no"
+
+
+def _is_supported_google_photos_host(hostname: str) -> bool:
+    """Return ``True`` if ``hostname`` looks like a Google Photos domain."""
+
+    host = (hostname or "").lower()
+    if not host:
+        return False
+
+    allowed_domains: Sequence[str] = (
+        "photos.app.goo.gl",
+        "photos.google.com",
+        "googleusercontent.com",
+        "ggpht.com",
+    )
+
+    return any(host == domain or host.endswith(f".{domain}") for domain in allowed_domains)
+
+
+def _strip_size_parameters(url: str) -> str:
+    """Remove size or query parameters from a Google Photos image URL."""
+
+    if not url:
+        return ""
+
+    base = url.split("=")[0]
+    base = base.split("?")[0]
+    return base.strip()
+
+
+def _unique(iterable: Iterable[str]) -> List[str]:
+    """Return ``iterable`` without duplicates while preserving order."""
+
+    seen = set()
+    result: List[str] = []
+    for item in iterable:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def fetch_google_photos_album(album_url: str, *, limit: int = DEFAULT_PHOTO_LIMIT) -> List[dict]:
+    """Return a list of preview images for the shared Google Photos album.
+
+    The function fetches the public album page and extracts any direct image URLs
+    that are embedded in the HTML payload. The images are returned as dictionaries
+    containing ``url`` and ``thumbnail_url`` keys that point to resized versions
+    of each photo suitable for display in the WanderLog UI.
+    """
+
+    cleaned_url = (album_url or "").strip()
+    if not cleaned_url:
+        return []
+
+    parsed = urlparse(cleaned_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Album URL must start with http:// or https://.")
+
+    if not _is_supported_google_photos_host(parsed.netloc):
+        raise ValueError("Album URL must be a Google Photos share link.")
+
+    request = Request(cleaned_url, headers={"User-Agent": USER_AGENT})
+
+    try:
+        with urlopen(request, timeout=10) as response:
+            content_bytes = response.read()
+    except (HTTPError, URLError, socket.timeout) as exc:  # pragma: no cover - network failure
+        raise RuntimeError("Failed to download album contents. Please try again later.") from exc
+
+    try:
+        html = content_bytes.decode("utf-8", errors="replace")
+    except Exception as exc:  # pragma: no cover - extremely unlikely decoding failure
+        raise RuntimeError("Album page could not be decoded.") from exc
+
+    matches = IMAGE_URL_PATTERN.findall(html)
+    if not matches:
+        raise RuntimeError("No photos were found in the shared album.")
+
+    base_urls = _unique(_strip_size_parameters(match) for match in matches)
+    if not base_urls:
+        raise RuntimeError("No photos were found in the shared album.")
+
+    photos = []
+    max_items = max(int(limit or 0), 0) or DEFAULT_PHOTO_LIMIT
+
+    for index, base_url in enumerate(base_urls[:max_items], start=1):
+        full_url = f"{base_url}={FULL_SIZE_PARAMETERS}"
+        thumb_url = f"{base_url}={THUMBNAIL_PARAMETERS}"
+        photos.append(
+            {
+                "id": f"photo-{index}",
+                "url": full_url,
+                "thumbnail_url": thumb_url,
+                "source_url": base_url,
+            }
+        )
+
+    return photos
+


### PR DESCRIPTION
## Summary
- add persistent `album_url` support to trips and expose it through the REST API
- fetch preview thumbnails from shared Google Photos albums on demand for each trip
- extend the trip profile UI with controls to edit the album link and display the photo gallery

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d59d2eae8483298228af633c67fe7c