### PR TITLE
Enable trip photo selection and filter profile images

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -597,6 +597,54 @@ button, input, select { font-family: inherit; }
     display: block;
 }
 
+.trip-profile-photo-item-selectable {
+    border: 2px solid transparent;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.trip-profile-photo-item-selectable .trip-profile-photo-toggle {
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.2;
+    border: none;
+    border-radius: 999px;
+    background: rgba(17, 24, 39, 0.85);
+    color: #f9fafb;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.trip-profile-photo-item-selectable .trip-profile-photo-toggle:hover,
+.trip-profile-photo-item-selectable .trip-profile-photo-toggle:focus-visible {
+    background: rgba(37, 99, 235, 0.9);
+    transform: translateY(-1px);
+}
+
+.trip-profile-photo-item-selectable .trip-profile-photo-toggle:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.trip-profile-photo-item-selected {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.trip-profile-photo-item-selectable .trip-profile-photo-toggle[aria-pressed="true"],
+.trip-profile-photo-item-selected .trip-profile-photo-toggle {
+    background: #2563eb;
+    color: #fff;
+}
+
 .trip-profile-updated-readonly {
     margin-top: 8px;
 }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -652,11 +652,23 @@ button, input, select { font-family: inherit; }
     transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
+html.photo-selector-html {
+    height: auto;
+    min-height: 100%;
+    overflow-y: auto;
+}
+
+html.photo-selector-html body {
+    height: auto;
+    min-height: 100vh;
+}
+
 .photo-selector-body {
     font-family: 'Raleway', 'Helvetica Neue', Arial, sans-serif;
     background: #f3f4f6;
     margin: 0;
     color: #111827;
+    overflow-y: auto;
 }
 
 .photo-selector {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -551,6 +551,12 @@ button, input, select { font-family: inherit; }
     gap: 12px;
 }
 
+.trip-profile-photos-links {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
 .trip-profile-photos-title {
     font-size: 16px;
     font-weight: 600;
@@ -571,6 +577,28 @@ button, input, select { font-family: inherit; }
     text-decoration: underline;
 }
 
+.trip-profile-photos-configure {
+    font-size: 13px;
+    font-weight: 600;
+    color: #2563eb;
+    background: rgba(37, 99, 235, 0.1);
+    border: 1px solid rgba(37, 99, 235, 0.35);
+    border-radius: 999px;
+    padding: 6px 14px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.trip-profile-photos-configure:hover,
+.trip-profile-photos-configure:focus-visible {
+    background: rgba(37, 99, 235, 0.18);
+    border-color: rgba(37, 99, 235, 0.6);
+}
+
+.trip-profile-photos-configure[hidden] {
+    display: none;
+}
+
 .trip-profile-photos-empty {
     font-size: 14px;
     color: #6b7280;
@@ -588,6 +616,7 @@ button, input, select { font-family: inherit; }
     border-radius: 16px;
     background: #e5e7eb;
     min-height: 120px;
+    border: 2px solid transparent;
 }
 
 .trip-profile-photo-item img {
@@ -621,6 +650,200 @@ button, input, select { font-family: inherit; }
     justify-content: center;
     gap: 6px;
     transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.photo-selector-body {
+    font-family: 'Raleway', 'Helvetica Neue', Arial, sans-serif;
+    background: #f3f4f6;
+    margin: 0;
+    color: #111827;
+}
+
+.photo-selector {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 32px 24px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    min-height: 100vh;
+}
+
+.photo-selector-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.photo-selector-header h1 {
+    font-size: 24px;
+    margin: 0 0 6px;
+}
+
+.photo-selector-trip-name {
+    margin: 0;
+    font-size: 16px;
+    color: #4b5563;
+}
+
+.photo-selector-album-link {
+    font-weight: 600;
+    color: #2563eb;
+    text-decoration: none;
+    border: 1px solid rgba(37, 99, 235, 0.4);
+    border-radius: 999px;
+    padding: 8px 16px;
+    background: rgba(37, 99, 235, 0.08);
+}
+
+.photo-selector-album-link:hover,
+.photo-selector-album-link:focus-visible {
+    text-decoration: underline;
+    background: rgba(37, 99, 235, 0.16);
+}
+
+.photo-selector-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.photo-selector-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.photo-selector-actions button {
+    border: 1px solid rgba(17, 24, 39, 0.15);
+    background: #fff;
+    color: #1f2937;
+    font-weight: 600;
+    padding: 8px 14px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.photo-selector-actions button:hover,
+.photo-selector-actions button:focus-visible {
+    background: #e5e7eb;
+    border-color: rgba(17, 24, 39, 0.3);
+}
+
+.photo-selector-summary {
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.photo-selector-status {
+    min-height: 20px;
+    font-size: 14px;
+    color: #047857;
+}
+
+.photo-selector-status-error {
+    color: #b91c1c;
+}
+
+.photo-selector-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 16px;
+}
+
+.photo-selector-item {
+    position: relative;
+    background: #e5e7eb;
+    border-radius: 18px;
+    overflow: hidden;
+    min-height: 160px;
+}
+
+.photo-selector-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.photo-selector-toggle {
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    background: rgba(17, 24, 39, 0.85);
+    color: #f9fafb;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 13px;
+    padding: 8px 14px;
+}
+
+.photo-selector-toggle input[type="checkbox"] {
+    margin: 0;
+    width: 16px;
+    height: 16px;
+}
+
+.photo-selector-toggle-label {
+    font-weight: 600;
+}
+
+.photo-selector-empty {
+    grid-column: 1 / -1;
+    font-size: 15px;
+    color: #6b7280;
+}
+
+.photo-selector-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: auto;
+}
+
+.photo-selector-primary,
+.photo-selector-secondary {
+    font-size: 15px;
+    font-weight: 600;
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: none;
+    cursor: pointer;
+}
+
+.photo-selector-primary {
+    background: #2563eb;
+    color: #fff;
+}
+
+.photo-selector-primary:hover,
+.photo-selector-primary:focus-visible {
+    background: #1d4ed8;
+}
+
+.photo-selector-secondary {
+    background: #e5e7eb;
+    color: #1f2937;
+}
+
+.photo-selector-secondary:hover,
+.photo-selector-secondary:focus-visible {
+    background: #d1d5db;
+}
+
+.photo-selector-primary:disabled,
+.photo-selector-secondary:disabled,
+.photo-selector-actions button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .trip-profile-photo-item-selectable .trip-profile-photo-toggle:hover,

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -784,18 +784,17 @@ html.photo-selector-html body {
 
 .photo-selector-toggle {
     position: absolute;
+    top: 12px;
     left: 12px;
-    right: 12px;
-    bottom: 12px;
     background: rgba(17, 24, 39, 0.85);
     color: #f9fafb;
-    border-radius: 999px;
+    border-radius: 12px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
-    font-size: 13px;
-    padding: 8px 14px;
+    gap: 6px;
+    font-size: 12px;
+    padding: 6px 10px;
 }
 
 .photo-selector-toggle input[type="checkbox"] {

--- a/app/static/js/photo_selector.js
+++ b/app/static/js/photo_selector.js
@@ -1,0 +1,239 @@
+/* global window, document, fetch */
+
+(function () {
+    'use strict';
+
+    const config = window.tripPhotoSelectorConfig || {};
+    const tripIdRaw = config && config.tripId !== undefined ? config.tripId : '';
+    const tripId = typeof tripIdRaw === 'string' ? tripIdRaw.trim() : String(tripIdRaw || '').trim();
+
+    const availableInitial = Array.isArray(config.availablePhotos) ? config.availablePhotos : [];
+    let availablePhotos = normalisePhotoList(availableInitial);
+    let selectedPhotos = normalisePhotoList(Array.isArray(config.selectedPhotos) ? config.selectedPhotos : []);
+
+    const statusElement = document.getElementById('photoSelectorStatus');
+    const gridElement = document.getElementById('photoSelectorGrid');
+    const selectAllButton = document.getElementById('photoSelectorSelectAll');
+    const clearAllButton = document.getElementById('photoSelectorClearAll');
+    const saveButton = document.getElementById('photoSelectorSave');
+    const closeButton = document.getElementById('photoSelectorClose');
+    const selectedCountElement = document.getElementById('photoSelectorSelectedCount');
+
+    function normalisePhotoList(values) {
+        if (!Array.isArray(values)) { return []; }
+        const seen = new Set();
+        const cleaned = [];
+        values.forEach((entry) => {
+            if (entry === null || entry === undefined) { return; }
+            const value = typeof entry === 'string' ? entry.trim() : String(entry || '').trim();
+            if (!value || seen.has(value)) { return; }
+            seen.add(value);
+            cleaned.push(value);
+        });
+        return cleaned;
+    }
+
+    function getDisplayPhotos() {
+        const fallback = normalisePhotoList(Array.isArray(config.availablePhotos) ? config.availablePhotos : []);
+        const combined = [...availablePhotos, ...fallback, ...selectedPhotos];
+        return normalisePhotoList(combined);
+    }
+
+    function showStatus(message, isError = false) {
+        if (!statusElement) { return; }
+        statusElement.textContent = message || '';
+        statusElement.classList.toggle('photo-selector-status-error', Boolean(isError));
+    }
+
+    function updateSelectedCount() {
+        if (!selectedCountElement) { return; }
+        selectedCountElement.textContent = String(selectedPhotos.length);
+    }
+
+    function renderPhotos() {
+        if (!gridElement) { return; }
+        const photos = getDisplayPhotos();
+        gridElement.innerHTML = '';
+
+        if (!Array.isArray(photos) || photos.length === 0) {
+            const emptyMessage = document.createElement('p');
+            emptyMessage.className = 'photo-selector-empty';
+            emptyMessage.textContent = 'No photos are available for this album.';
+            gridElement.appendChild(emptyMessage);
+            return;
+        }
+
+        const selectedSet = new Set(selectedPhotos);
+
+        photos.forEach((photoUrl, index) => {
+            const cleaned = typeof photoUrl === 'string' ? photoUrl.trim() : String(photoUrl || '').trim();
+            if (!cleaned) { return; }
+
+            const figure = document.createElement('figure');
+            figure.className = 'photo-selector-item';
+            figure.setAttribute('role', 'listitem');
+
+            const image = document.createElement('img');
+            image.src = cleaned;
+            image.alt = `Photo ${index + 1}`;
+            image.loading = 'lazy';
+            image.decoding = 'async';
+            figure.appendChild(image);
+
+            const label = document.createElement('label');
+            label.className = 'photo-selector-toggle';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.value = cleaned;
+            checkbox.checked = selectedSet.has(cleaned);
+            label.appendChild(checkbox);
+
+            const caption = document.createElement('span');
+            caption.textContent = checkbox.checked ? 'Selected' : 'Select photo';
+            caption.className = 'photo-selector-toggle-label';
+            label.appendChild(caption);
+
+            figure.appendChild(label);
+            gridElement.appendChild(figure);
+        });
+
+        updateSelectedCount();
+    }
+
+    function setSavingState(isSaving) {
+        const disabled = Boolean(isSaving);
+        if (saveButton) { saveButton.disabled = disabled; }
+        if (closeButton) { closeButton.disabled = disabled; }
+        if (selectAllButton) { selectAllButton.disabled = disabled; }
+        if (clearAllButton) { clearAllButton.disabled = disabled; }
+        if (gridElement) {
+            const inputs = gridElement.querySelectorAll('input[type="checkbox"]');
+            inputs.forEach((input) => { input.disabled = disabled; });
+        }
+    }
+
+    function togglePhotoSelection(url, selected) {
+        const cleaned = typeof url === 'string' ? url.trim() : '';
+        if (!cleaned) { return; }
+        const current = normalisePhotoList(selectedPhotos);
+        const index = current.indexOf(cleaned);
+        if (selected) {
+            if (index === -1) {
+                current.push(cleaned);
+            }
+        } else if (index !== -1) {
+            current.splice(index, 1);
+        }
+        selectedPhotos = current;
+        updateSelectedCount();
+    }
+
+    async function saveSelection() {
+        if (!tripId) {
+            showStatus('This trip could not be identified.', true);
+            return;
+        }
+
+        setSavingState(true);
+        showStatus('Saving selection...');
+
+        const payload = { selected_photos: selectedPhotos };
+
+        try {
+            const response = await fetch(`/api/trips/${encodeURIComponent(tripId)}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+
+            const result = await response.json().catch(() => ({}));
+
+            if (!response.ok || (result && result.status === 'error')) {
+                const message = (result && result.message) ? result.message : 'Failed to save selection.';
+                throw new Error(message);
+            }
+
+            availablePhotos = normalisePhotoList(
+                Array.isArray(result.available_photos) ? result.available_photos : availablePhotos
+            );
+            selectedPhotos = normalisePhotoList(
+                Array.isArray(result.selected_photos) ? result.selected_photos : selectedPhotos
+            );
+
+            renderPhotos();
+            showStatus(result.message || 'Trip photos updated successfully.');
+
+            if (window.opener && !window.opener.closed) {
+                const message = {
+                    type: 'trip-photos-updated',
+                    tripId,
+                    selected_photos: selectedPhotos,
+                    available_photos: availablePhotos
+                };
+                try {
+                    window.opener.postMessage(message, window.location.origin);
+                } catch (error) {
+                    console.error('Failed to notify opener window about photo update.', error);
+                }
+            }
+        } catch (error) {
+            console.error('Failed to save photo selection', error);
+            showStatus(error.message || 'Failed to save selection.', true);
+            return;
+        } finally {
+            setSavingState(false);
+        }
+    }
+
+    function bindEvents() {
+        if (gridElement) {
+            gridElement.addEventListener('change', (event) => {
+                const target = event.target instanceof HTMLInputElement ? event.target : null;
+                if (!target || target.type !== 'checkbox') { return; }
+                togglePhotoSelection(target.value, target.checked);
+                if (target.nextElementSibling) {
+                    target.nextElementSibling.textContent = target.checked ? 'Selected' : 'Select photo';
+                }
+            });
+        }
+
+        if (selectAllButton) {
+            selectAllButton.addEventListener('click', () => {
+                const all = getDisplayPhotos();
+                selectedPhotos = [...all];
+                renderPhotos();
+                showStatus('All photos selected.');
+            });
+        }
+
+        if (clearAllButton) {
+            clearAllButton.addEventListener('click', () => {
+                selectedPhotos = [];
+                renderPhotos();
+                showStatus('Selection cleared.');
+            });
+        }
+
+        if (saveButton) {
+            saveButton.addEventListener('click', () => {
+                saveSelection();
+            });
+        }
+
+        if (closeButton) {
+            closeButton.addEventListener('click', () => {
+                window.close();
+            });
+        }
+
+        window.addEventListener('beforeunload', () => {
+            if (window.opener && !window.opener.closed) {
+                window.opener.postMessage({ type: 'trip-photo-configurator-closed', tripId }, window.location.origin);
+            }
+        });
+    }
+
+    renderPhotos();
+    bindEvents();
+})();

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -268,7 +268,10 @@
                 <div id="tripPhotosSection" class="trip-profile-photos" aria-live="polite" hidden>
                     <div class="trip-profile-photos-header">
                         <h3 class="trip-profile-photos-title">Trip photos</h3>
-                        <a id="tripPhotosLink" class="trip-profile-photos-link" href="#" target="_blank" rel="noopener" hidden>Open album</a>
+                        <div class="trip-profile-photos-links">
+                            <a id="tripPhotosLink" class="trip-profile-photos-link" href="#" target="_blank" rel="noopener" hidden>Open album</a>
+                            <button type="button" id="tripPhotosConfigure" class="trip-profile-photos-configure" hidden>Configure displayed photos</button>
+                        </div>
                     </div>
                     <p id="tripPhotosEmpty" class="trip-profile-photos-empty">Add a Google Photos album link to see photos here.</p>
                     <div id="tripPhotosGallery" class="trip-profile-photos-gallery" role="list" hidden></div>

--- a/app/templates/photo_selector.html
+++ b/app/templates/photo_selector.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="photo-selector-html">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/templates/photo_selector.html
+++ b/app/templates/photo_selector.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Configure Trip Photos</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+<body class="photo-selector-body">
+    <main class="photo-selector" aria-labelledby="photoSelectorTitle">
+        <header class="photo-selector-header">
+            <div>
+                <h1 id="photoSelectorTitle">Configure Trip Photos</h1>
+                <p class="photo-selector-trip-name">{{ trip.name }}</p>
+            </div>
+            {% if photos_url %}
+            <a class="photo-selector-album-link" href="{{ photos_url }}" target="_blank" rel="noopener">Open album</a>
+            {% endif %}
+        </header>
+        <section class="photo-selector-controls" aria-label="Photo selection controls">
+            <div class="photo-selector-actions">
+                <button type="button" id="photoSelectorSelectAll">Select all</button>
+                <button type="button" id="photoSelectorClearAll">Clear all</button>
+            </div>
+            <div class="photo-selector-summary">
+                <span id="photoSelectorSelectedCount">0</span> selected
+            </div>
+        </section>
+        <p id="photoSelectorStatus" class="photo-selector-status" role="status" aria-live="polite"></p>
+        <div id="photoSelectorGrid" class="photo-selector-grid" role="list"></div>
+        <footer class="photo-selector-footer">
+            <button type="button" id="photoSelectorClose" class="photo-selector-secondary">Close</button>
+            <button type="button" id="photoSelectorSave" class="photo-selector-primary">Save selection</button>
+        </footer>
+    </main>
+    <script>
+        window.tripPhotoSelectorConfig = {
+            tripId: {{ trip.id|tojson }},
+            tripName: {{ trip.name|tojson }},
+            photosUrl: {{ photos_url|tojson }},
+            availablePhotos: {{ available_photos|tojson }},
+            selectedPhotos: {{ selected_photos|tojson }}
+        };
+    </script>
+    <script src="{{ url_for('static', filename='js/photo_selector.js') }}" defer></script>
+</body>
+</html>

--- a/app/utils/google_photos.py
+++ b/app/utils/google_photos.py
@@ -19,6 +19,27 @@ _CacheEntry = tuple[float, List[str]]
 _CACHE: Dict[str, _CacheEntry] = {}
 
 
+def _is_profile_image_url(url: str) -> bool:
+    """Return ``True`` when ``url`` looks like a Google profile avatar."""
+
+    if not url:
+        return False
+
+    lowered = url.lower()
+
+    if "googleusercontent.com/a/" in lowered:
+        return True
+
+    profile_pattern = re.compile(r"=s\d{1,4}-(?:c|p)(?:$|[^a-z0-9])")
+    if profile_pattern.search(lowered):
+        return True
+
+    if "=s96" in lowered or "=s120" in lowered or "=s128" in lowered:
+        return True
+
+    return False
+
+
 def _clean_url(url: str) -> str:
     if not isinstance(url, str):
         return ""
@@ -83,6 +104,8 @@ def _extract_image_urls(html: str, *, max_images: int) -> List[str]:
         if base in seen_bases:
             continue
         seen_bases.add(base)
+        if _is_profile_image_url(candidate):
+            continue
         results.append(_normalise_resolution(candidate))
         if len(results) >= max_images:
             break


### PR DESCRIPTION
## Summary
- allow trips to persist selected photo URLs and expose them via the API
- add front-end controls to select or deselect album images and style the selection state
- filter out Google profile avatars when scraping shared Google Photos albums

## Testing
- pytest
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d6a479af6883298b47425f5188a8da