### PR TITLE
Use Google Photos API for album ingestion

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,43 @@
+"""Application configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class GooglePhotosSettings:
+    """Configuration values required for the Google Photos client."""
+
+    client_id: str
+    client_secret: str
+    refresh_token: str
+    shared_album_id: Optional[str] = None
+    api_base_url: str = "https://photoslibrary.googleapis.com"
+    token_url: str = "https://oauth2.googleapis.com/token"
+
+
+def load_google_photos_settings() -> GooglePhotosSettings:
+    """Load configuration for the Google Photos API from environment variables."""
+
+    client_id = os.getenv("GOOGLE_PHOTOS_CLIENT_ID", "").strip()
+    client_secret = os.getenv("GOOGLE_PHOTOS_CLIENT_SECRET", "").strip()
+    refresh_token = os.getenv("GOOGLE_PHOTOS_REFRESH_TOKEN", "").strip()
+    shared_album_id = os.getenv("GOOGLE_PHOTOS_SHARED_ALBUM_ID")
+    if shared_album_id:
+        shared_album_id = shared_album_id.strip()
+
+    if not client_id or not client_secret or not refresh_token:
+        raise RuntimeError(
+            "Missing Google Photos OAuth configuration. Set GOOGLE_PHOTOS_CLIENT_ID, "
+            "GOOGLE_PHOTOS_CLIENT_SECRET, and GOOGLE_PHOTOS_REFRESH_TOKEN."
+        )
+
+    return GooglePhotosSettings(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+        shared_album_id=shared_album_id or None,
+    )

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service modules for WanderLog."""

--- a/app/services/google_photos_api.py
+++ b/app/services/google_photos_api.py
@@ -1,0 +1,161 @@
+"""Google Photos API client used to read shared album media."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import requests
+from requests import Response
+
+from app.config import GooglePhotosSettings, load_google_photos_settings
+
+_LOGGER = logging.getLogger(__name__)
+_DEFAULT_PAGE_SIZE = 100
+_TOKEN_EXPIRY_SAFETY_WINDOW = 60  # seconds
+
+
+class GooglePhotosAPIError(RuntimeError):
+    """Raised when the Google Photos API returns an error response."""
+
+
+@dataclass
+class _TokenCache:
+    access_token: str
+    expires_at: float
+
+    def is_valid(self, now: float) -> bool:
+        return bool(self.access_token) and now + _TOKEN_EXPIRY_SAFETY_WINDOW < self.expires_at
+
+
+class GooglePhotosClient:
+    """Client capable of fetching media items from a shared album."""
+
+    def __init__(
+        self,
+        settings: GooglePhotosSettings,
+        *,
+        session: Optional[requests.Session] = None,
+        clock=time.time,
+    ) -> None:
+        self._settings = settings
+        self._session = session or requests.Session()
+        self._clock = clock
+        self._token_cache: Optional[_TokenCache] = None
+
+    @classmethod
+    def from_environment(cls) -> "GooglePhotosClient":
+        return cls(load_google_photos_settings())
+
+    @property
+    def settings(self) -> GooglePhotosSettings:
+        return self._settings
+
+    def list_media_items(self, shared_album_id: str) -> List[Dict]:
+        """Return all media items for the specified shared album."""
+
+        if not shared_album_id:
+            raise GooglePhotosAPIError("A shared album id is required to call mediaItems.search")
+
+        media_items: List[Dict] = []
+        page_token: Optional[str] = None
+
+        while True:
+            payload: Dict[str, object] = {"albumId": shared_album_id, "pageSize": _DEFAULT_PAGE_SIZE}
+            if page_token:
+                payload["pageToken"] = page_token
+
+            response = self._authenticated_post("/v1/mediaItems:search", json=payload)
+            data = self._extract_json(response)
+
+            items = data.get("mediaItems", []) or []
+            if not isinstance(items, list):
+                raise GooglePhotosAPIError("Unexpected mediaItems payload from Google Photos API")
+            media_items.extend(item for item in items if isinstance(item, dict))
+
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                break
+
+        return media_items
+
+    # ------------------------------------------------------------------
+    def _authenticated_post(self, path: str, *, json: Dict[str, object]) -> Response:
+        token = self._get_access_token()
+        url = f"{self._settings.api_base_url}{path}"
+        headers = {"Authorization": f"Bearer {token}"}
+
+        try:
+            response = self._session.post(url, json=json, headers=headers, timeout=15)
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise GooglePhotosAPIError("Error calling Google Photos API") from exc
+
+        if response.status_code >= 400:
+            raise GooglePhotosAPIError(
+                f"Google Photos API returned {response.status_code}: {response.text.strip()}"
+            )
+        return response
+
+    def _get_access_token(self) -> str:
+        now = self._clock()
+        if self._token_cache and self._token_cache.is_valid(now):
+            return self._token_cache.access_token
+
+        payload = {
+            "client_id": self._settings.client_id,
+            "client_secret": self._settings.client_secret,
+            "refresh_token": self._settings.refresh_token,
+            "grant_type": "refresh_token",
+        }
+
+        try:
+            response = self._session.post(self._settings.token_url, data=payload, timeout=15)
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise GooglePhotosAPIError("Unable to refresh Google Photos access token") from exc
+
+        if response.status_code >= 400:
+            raise GooglePhotosAPIError(
+                f"Google Photos token endpoint returned {response.status_code}: {response.text.strip()}"
+            )
+
+        data = self._extract_json(response)
+        access_token = data.get("access_token")
+        expires_in = data.get("expires_in")
+        if not access_token or not expires_in:
+            raise GooglePhotosAPIError("Invalid token response from Google OAuth endpoint")
+
+        try:
+            expires_at = now + float(expires_in)
+        except (TypeError, ValueError) as exc:
+            raise GooglePhotosAPIError("Invalid expires_in value in token response") from exc
+
+        self._token_cache = _TokenCache(access_token=access_token, expires_at=expires_at)
+        return access_token
+
+    def _extract_json(self, response: Response) -> Dict:
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - handled as an error case
+            raise GooglePhotosAPIError("Failed to decode Google Photos response as JSON") from exc
+
+        if not isinstance(payload, dict):
+            raise GooglePhotosAPIError("Unexpected payload returned by Google Photos API")
+        return payload
+
+
+_client_instance: Optional[GooglePhotosClient] = None
+
+
+def get_google_photos_client() -> GooglePhotosClient:
+    """Return a cached GooglePhotosClient instance."""
+
+    global _client_instance
+    if _client_instance is None:
+        try:
+            _client_instance = GooglePhotosClient.from_environment()
+        except RuntimeError as exc:
+            _LOGGER.warning("Google Photos client is not configured: %s", exc)
+            raise
+    return _client_instance

--- a/app/utils/google_photos.py
+++ b/app/utils/google_photos.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
-import re
+import logging
 import time
-from html import unescape
-from typing import Dict, List
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from typing import Dict, Iterable, List, Optional
 
+from app.services.google_photos_api import (
+    GooglePhotosAPIError,
+    GooglePhotosClient,
+    get_google_photos_client,
+)
+
+_LOGGER = logging.getLogger(__name__)
 _CACHE_TTL_SECONDS = 3600
 _DEFAULT_MAX_IMAGES = 50
-_USER_AGENT = (
-    "Mozilla/5.0 (compatible; WanderLog/1.0; +https://github.com/)"
-)
+_PREFERRED_WIDTH = 2048
+_AVATAR_KEYWORDS = ("avatar", "profile", "userphoto", "contacts")
 
 _CacheEntry = tuple[float, List[str]]
 _CACHE: Dict[str, _CacheEntry] = {}
@@ -25,69 +28,71 @@ def _clean_url(url: str) -> str:
     return url.strip()
 
 
-def _fetch_html(url: str) -> str:
+def _extract_album_token(url: str) -> Optional[str]:
     if not url:
+        return None
+    cleaned = url.rstrip("/")
+    token = cleaned.split("/")[-1]
+    return token or None
+
+
+def _normalise_resolution(base_url: str) -> str:
+    if not base_url:
         return ""
-
-    request = Request(url, headers={"User-Agent": _USER_AGENT})
-    try:
-        with urlopen(request, timeout=15) as response:  # nosec: trusted domain
-            content_bytes = response.read()
-    except (HTTPError, URLError, TimeoutError):
-        return ""
-    except Exception:
-        return ""
-
-    try:
-        return content_bytes.decode("utf-8", errors="replace")
-    except Exception:
-        return ""
+    if base_url.endswith("="):
+        base_url = base_url[:-1]
+    if "=" in base_url:
+        # Replace any existing size directives to request the preferred width.
+        prefix, _ = base_url.split("=", 1)
+        return f"{prefix}=w{_PREFERRED_WIDTH}"
+    return f"{base_url}=w{_PREFERRED_WIDTH}"
 
 
-def _normalise_resolution(url: str) -> str:
-    if not url:
-        return ""
+def _is_avatar(item: Dict, url: str) -> bool:
+    filename = str(item.get("filename", "")).lower()
+    description = str(item.get("description", "")).lower()
+    metadata = item.get("mediaMetadata", {}) or {}
+    photo_meta = metadata.get("photo", {}) or {}
+    camera_model = str(photo_meta.get("cameraModel", "")).lower()
 
-    updated = re.sub(r"=w\d+", "=w2048", url)
-    updated = re.sub(r"-w\d+", "-w2048", updated)
-    updated = re.sub(r"-h\d+", "-h2048", updated)
-    updated = re.sub(r"=s\d+", "=s2048", updated)
-    if "=" not in updated:
-        updated = f"{updated}=w2048"
-    return updated
+    searchable_values: Iterable[str] = (filename, description, camera_model, url.lower())
+    return any(keyword in value for value in searchable_values for keyword in _AVATAR_KEYWORDS)
 
 
-def _extract_image_urls(html: str, *, max_images: int) -> List[str]:
-    if not html:
-        return []
+def _is_supported_image(item: Dict) -> bool:
+    mime_type = str(item.get("mimeType", "")).lower()
+    return mime_type.startswith("image/")
 
-    normalised = unescape(html)
-    normalised = (
-        normalised
-        .replace("\\u003d", "=")
-        .replace("\\u0026", "&")
-        .replace("\\u002f", "/")
-    )
 
-    pattern = re.compile(r"(?:https?:)?//lh3\.googleusercontent\.com/[^\s\"']+")
-    matches = pattern.findall(normalised)
-
-    results: List[str] = []
-    seen_bases = set()
-    for match in matches:
-        candidate = match.split("\\")[0]
-        candidate = candidate.split('"')[0]
-        if candidate.startswith("//"):
-            candidate = f"https:{candidate}"
-        base = candidate.split("=")[0]
-        if base in seen_bases:
+def _translate_media_items(items: Iterable[Dict], *, max_images: int) -> List[str]:
+    images: List[str] = []
+    for item in items:
+        if not isinstance(item, dict):
             continue
-        seen_bases.add(base)
-        results.append(_normalise_resolution(candidate))
-        if len(results) >= max_images:
+        if not _is_supported_image(item):
+            continue
+
+        base_url = str(item.get("baseUrl", ""))
+        if not base_url:
+            continue
+
+        full_url = _normalise_resolution(base_url)
+        if not full_url or _is_avatar(item, full_url):
+            continue
+
+        images.append(full_url)
+        if len(images) >= max_images:
             break
 
-    return results
+    return images
+
+
+def _fetch_media_items(client: GooglePhotosClient, album_id: str) -> List[Dict]:
+    try:
+        return client.list_media_items(album_id)
+    except GooglePhotosAPIError as exc:
+        _LOGGER.warning("Failed to load Google Photos album: %s", exc)
+        return []
 
 
 def fetch_album_images(url: str, *, max_images: int = _DEFAULT_MAX_IMAGES) -> List[str]:
@@ -97,13 +102,24 @@ def fetch_album_images(url: str, *, max_images: int = _DEFAULT_MAX_IMAGES) -> Li
     if not cleaned_url:
         return []
 
-    cache_entry = _CACHE.get(cleaned_url)
     now = time.time()
+    cache_entry = _CACHE.get(cleaned_url)
     if cache_entry and now - cache_entry[0] < _CACHE_TTL_SECONDS:
         return list(cache_entry[1])
 
-    html = _fetch_html(cleaned_url)
-    images = _extract_image_urls(html, max_images=max_images)
+    try:
+        client = get_google_photos_client()
+    except RuntimeError:
+        _LOGGER.info("Google Photos client is not configured; skipping fetch")
+        return []
+
+    album_id = client.settings.shared_album_id or _extract_album_token(cleaned_url)
+    if not album_id:
+        _LOGGER.warning("No shared album identifier is configured or present in the URL")
+        return []
+
+    media_items = _fetch_media_items(client, album_id)
+    images = _translate_media_items(media_items, max_images=max_images)
 
     _CACHE[cleaned_url] = (now, images)
     return list(images)

--- a/readme.txt
+++ b/readme.txt
@@ -5,3 +5,4 @@ v0.3 - added dates to map marker popup data.  Made map rendering dynamic, and fa
 v0.4 - updated UI, added data type filtering, cleaned up code
 v0.5 - added archiving/deleting of data points, backups for timeline data on clear map, warnings for clear map & deleting of data points, and date range filtering
 v0.6 - added "Trips" prototype, added edit mode with multi-selection/editing of data points, updates to UI, fixed sorting, added descriptions to Trips
+v0.7 - switched Google Photos ingestion to the official API. Configure GOOGLE_PHOTOS_CLIENT_ID, GOOGLE_PHOTOS_CLIENT_SECRET, GOOGLE_PHOTOS_REFRESH_TOKEN, and GOOGLE_PHOTOS_SHARED_ALBUM_ID environment variables before running the server.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.0
 folium==0.15.0
 pandas==2.1.4
 python-dotenv==1.0.0
+requests==2.31.0
+pytest==7.4.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_google_photos.py
+++ b/tests/test_google_photos.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.config import GooglePhotosSettings
+from app.services.google_photos_api import GooglePhotosClient
+from app.utils import google_photos
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = "payload"
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, media_pages):
+        self.media_pages = list(media_pages)
+        self.media_call_count = 0
+        self.token_call_count = 0
+
+    def post(self, url, json=None, headers=None, data=None, timeout=None):
+        if json is None:
+            self.token_call_count += 1
+            return FakeResponse({"access_token": "token", "expires_in": 3600})
+
+        if self.media_call_count >= len(self.media_pages):
+            pytest.fail("Unexpected extra mediaItems.search call")
+        payload = self.media_pages[self.media_call_count]
+        self.media_call_count += 1
+        return FakeResponse(payload)
+
+
+def test_google_photos_client_paginates_until_token_exhausted():
+    pages = [
+        {"mediaItems": [{"id": "1"}], "nextPageToken": "next"},
+        {"mediaItems": [{"id": "2"}, {"id": "3"}]},
+    ]
+    session = FakeSession(pages)
+    settings = GooglePhotosSettings(
+        client_id="id", client_secret="secret", refresh_token="refresh", shared_album_id="album"
+    )
+    client = GooglePhotosClient(settings, session=session, clock=lambda: 0)
+
+    items = client.list_media_items("album")
+
+    assert [item["id"] for item in items] == ["1", "2", "3"]
+    assert session.media_call_count == 2
+    assert session.token_call_count == 1
+
+
+def test_fetch_album_images_uses_cache(monkeypatch):
+    google_photos._CACHE.clear()
+
+    calls = {"count": 0}
+
+    def list_media_items(_album_id):
+        calls["count"] += 1
+        return [
+            {"mimeType": "image/jpeg", "baseUrl": "https://example.com/photo"},
+        ]
+
+    client = SimpleNamespace(
+        settings=SimpleNamespace(shared_album_id="album"),
+        list_media_items=list_media_items,
+    )
+
+    monkeypatch.setattr(google_photos, "get_google_photos_client", lambda: client)
+
+    first = google_photos.fetch_album_images("https://photos.app.goo.gl/demo")
+    second = google_photos.fetch_album_images("https://photos.app.goo.gl/demo")
+
+    assert first == ["https://example.com/photo=w2048"]
+    assert second == first
+    assert calls["count"] == 1
+
+
+def test_fetch_album_images_filters_avatars(monkeypatch):
+    google_photos._CACHE.clear()
+
+    items = [
+        {"mimeType": "image/jpeg", "baseUrl": "https://example.com/avatar", "filename": "avatar.jpg"},
+        {"mimeType": "image/png", "baseUrl": "https://example.com/keep", "filename": "holiday.png"},
+        {"mimeType": "video/mp4", "baseUrl": "https://example.com/video"},
+    ]
+
+    client = SimpleNamespace(
+        settings=SimpleNamespace(shared_album_id="album"),
+        list_media_items=lambda _album_id: items,
+    )
+    monkeypatch.setattr(google_photos, "get_google_photos_client", lambda: client)
+
+    results = google_photos.fetch_album_images("https://photos.app.goo.gl/demo")
+
+    assert results == ["https://example.com/keep=w2048"]


### PR DESCRIPTION
## Summary
- add a reusable Google Photos API client that refreshes OAuth tokens and iterates mediaItems pages
- switch the album ingestion helper to use the API client, reuse cached responses, and filter avatar images
- document the new environment variables and add pytest coverage for pagination, caching, and filtering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7060ea70c832992905ccea4f0529a