### PR TITLE
Improve Google Photos token store fallback

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ def create_app():
     load_dotenv()
 
     app = Flask(__name__)
+    app.secret_key = os.getenv("FLASK_SECRET_KEY", "dev-secret-key")
 
     # Load cached timeline data once during application startup
     data_cache.load_timeline_data()

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,92 @@
+"""Application configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv
+
+from app.services.google_photos_token_store import load_refresh_token
+
+GOOGLE_PHOTOS_READONLY_SCOPE = "https://www.googleapis.com/auth/photoslibrary.readonly"
+GOOGLE_PHOTOS_SHARING_SCOPE = "https://www.googleapis.com/auth/photoslibrary.sharing"
+DEFAULT_GOOGLE_PHOTOS_OAUTH_SCOPE = (
+    f"{GOOGLE_PHOTOS_READONLY_SCOPE} {GOOGLE_PHOTOS_SHARING_SCOPE}"
+)
+
+# Ensure values from a local .env file are available before any configuration
+# helpers attempt to read from the environment. ``load_dotenv`` is a no-op when
+# the file does not exist which keeps imports lightweight for other callers.
+load_dotenv()
+
+
+@dataclass(frozen=True)
+class GooglePhotosSettings:
+    """Configuration values required for the Google Photos client."""
+
+    client_id: str
+    client_secret: str
+    refresh_token: str
+    shared_album_id: Optional[str] = None
+    api_base_url: str = "https://photoslibrary.googleapis.com"
+    token_url: str = "https://oauth2.googleapis.com/token"
+
+
+@dataclass(frozen=True)
+class GooglePhotosOAuthClientSettings:
+    """Configuration required to initiate the Google Photos OAuth flow."""
+
+    client_id: str
+    client_secret: str
+    scope: str = DEFAULT_GOOGLE_PHOTOS_OAUTH_SCOPE
+    auth_base_url: str = "https://accounts.google.com/o/oauth2/v2/auth"
+    token_url: str = "https://oauth2.googleapis.com/token"
+
+
+def load_google_photos_settings() -> GooglePhotosSettings:
+    """Load configuration for the Google Photos API from environment variables."""
+
+    client_id = os.getenv("GOOGLE_PHOTOS_CLIENT_ID", "").strip()
+    client_secret = os.getenv("GOOGLE_PHOTOS_CLIENT_SECRET", "").strip()
+    refresh_token = os.getenv("GOOGLE_PHOTOS_REFRESH_TOKEN", "").strip()
+    if not refresh_token:
+        stored_refresh_token = load_refresh_token()
+        if stored_refresh_token:
+            refresh_token = stored_refresh_token
+    shared_album_id = os.getenv("GOOGLE_PHOTOS_SHARED_ALBUM_ID")
+    if shared_album_id:
+        shared_album_id = shared_album_id.strip()
+
+    if not client_id or not client_secret or not refresh_token:
+        raise RuntimeError(
+            "Missing Google Photos OAuth configuration. Set GOOGLE_PHOTOS_CLIENT_ID and "
+            "GOOGLE_PHOTOS_CLIENT_SECRET, then connect Google Photos through the in-app "
+            "sign-in flow."
+        )
+
+    return GooglePhotosSettings(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+        shared_album_id=shared_album_id or None,
+    )
+
+
+def load_google_photos_oauth_client_settings() -> GooglePhotosOAuthClientSettings:
+    """Return OAuth configuration without requiring a refresh token."""
+
+    client_id = os.getenv("GOOGLE_PHOTOS_CLIENT_ID", "").strip()
+    client_secret = os.getenv("GOOGLE_PHOTOS_CLIENT_SECRET", "").strip()
+
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Missing Google Photos OAuth client configuration. Set GOOGLE_PHOTOS_CLIENT_ID "
+            "and GOOGLE_PHOTOS_CLIENT_SECRET."
+        )
+
+    return GooglePhotosOAuthClientSettings(
+        client_id=client_id,
+        client_secret=client_secret,
+    )

--- a/app/scripts/google_photos_oauth.py
+++ b/app/scripts/google_photos_oauth.py
@@ -1,0 +1,200 @@
+"""Helper script to perform the Google Photos OAuth consent flow locally.
+
+Run ``python -m app.scripts.google_photos_oauth`` and follow the prompts to
+obtain a refresh token for the configured Google Cloud OAuth client.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import logging
+import socket
+import threading
+import urllib.parse
+import webbrowser
+from contextlib import closing
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+
+from app.config import DEFAULT_GOOGLE_PHOTOS_OAUTH_SCOPE
+
+load_dotenv()
+
+_AUTH_BASE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_DEFAULT_SCOPE = DEFAULT_GOOGLE_PHOTOS_OAUTH_SCOPE
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class OAuthClientConfig:
+    """OAuth client configuration used for the consent flow."""
+
+    client_id: str
+    client_secret: str
+    redirect_port: int = 8765
+    token_url: str = "https://oauth2.googleapis.com/token"
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://localhost:{self.redirect_port}/oauth2callback"
+
+
+class _AuthorizationCodeReceiver(http.server.BaseHTTPRequestHandler):
+    """Minimal HTTP handler that captures the ``code`` query parameter."""
+
+    server_version = "GooglePhotosOAuth/1.0"
+    _code: Optional[str] = None
+    _event: threading.Event
+
+    def __init__(self, *args, event: threading.Event, **kwargs):  # type: ignore[override]
+        self._event = event
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self):  # noqa: N802 - method name defined by BaseHTTPRequestHandler
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        code = params.get("code", [None])[0]
+        if code:
+            type(self)._code = code
+            message = "Authentication complete. You can close this window."
+        else:
+            message = "Missing authorization code."
+        self._event.set()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(message.encode("utf-8"))
+
+    def log_message(self, format: str, *args):  # noqa: A003 - keep signature from base class
+        _LOGGER.debug("OAuth redirect received: " + format, *args)
+
+
+def _find_free_port(preferred: int) -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        try:
+            sock.bind(("", preferred))
+        except OSError:
+            sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _build_auth_url(config: OAuthClientConfig, *, scope: str, state: Optional[str]) -> str:
+    params = {
+        "client_id": config.client_id,
+        "redirect_uri": config.redirect_uri,
+        "response_type": "code",
+        "access_type": "offline",
+        "prompt": "consent",
+        "scope": scope,
+    }
+    if state:
+        params["state"] = state
+    query = urllib.parse.urlencode(params, doseq=True)
+    return f"{_AUTH_BASE_URL}?{query}"
+
+
+def _exchange_code_for_tokens(config: OAuthClientConfig, code: str) -> dict:
+    payload = {
+        "client_id": config.client_id,
+        "client_secret": config.client_secret,
+        "code": code,
+        "grant_type": "authorization_code",
+        "redirect_uri": config.redirect_uri,
+    }
+    response = requests.post(config.token_url, data=payload, timeout=15)
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"Token exchange failed with status {response.status_code}: {response.text.strip()}"
+        )
+    data = response.json()
+    if not isinstance(data, dict):
+        raise RuntimeError("Unexpected response payload when exchanging authorization code")
+    if "refresh_token" not in data:
+        raise RuntimeError(
+            "No refresh_token returned. Ensure you selected the correct project and scopes."
+        )
+    return data
+
+
+def run_oauth_flow(config: OAuthClientConfig, *, scope: str = _DEFAULT_SCOPE) -> dict:
+    """Run the OAuth flow and return the token payload."""
+
+    port = _find_free_port(config.redirect_port)
+    config.redirect_port = port
+
+    ready = threading.Event()
+    _AuthorizationCodeReceiver._code = None
+
+    def handler_factory(*args, **kwargs):
+        return _AuthorizationCodeReceiver(*args, event=ready, **kwargs)
+
+    server = http.server.HTTPServer(("", port), handler_factory)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    auth_url = _build_auth_url(config, scope=scope, state=None)
+    print("Opening browser for Google consent. If nothing happens, visit:")
+    print(auth_url)
+    webbrowser.open(auth_url, new=1, autoraise=True)
+
+    print("Waiting for Google OAuth redirect...")
+    ready.wait()
+    server.shutdown()
+    thread.join(timeout=5)
+
+    code = _AuthorizationCodeReceiver._code
+    if not code:
+        raise RuntimeError("Authorization code not captured from redirect")
+
+    tokens = _exchange_code_for_tokens(config, code)
+    print("Access token:", tokens.get("access_token"))
+    print("Refresh token:", tokens.get("refresh_token"))
+    print("Token response:", tokens)
+    return tokens
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Google Photos OAuth helper")
+    parser.add_argument("--client-id", dest="client_id", default=None)
+    parser.add_argument("--client-secret", dest="client_secret", default=None)
+    parser.add_argument(
+        "--scope",
+        dest="scope",
+        default=_DEFAULT_SCOPE,
+        help=(
+            "OAuth scope to request (default: photoslibrary.readonly and "
+            "photoslibrary.sharing)"
+        ),
+    )
+    parser.add_argument(
+        "--redirect-port",
+        dest="redirect_port",
+        type=int,
+        default=8765,
+        help="Local port used to capture the OAuth redirect",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client_id = args.client_id or input("Google OAuth client ID: ").strip()
+    client_secret = args.client_secret or input("Google OAuth client secret: ").strip()
+    if not client_id or not client_secret:
+        raise SystemExit("Client ID and secret are required to run the OAuth helper")
+
+    config = OAuthClientConfig(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_port=args.redirect_port,
+    )
+    run_oauth_flow(config, scope=args.scope)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service modules for WanderLog."""

--- a/app/services/google_photos_api.py
+++ b/app/services/google_photos_api.py
@@ -1,0 +1,267 @@
+"""Google Photos API client used to read shared album media."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import requests
+from requests import Response
+
+from app.config import GooglePhotosSettings, load_google_photos_settings
+from app.services.google_photos_token_store import save_tokens
+
+_LOGGER = logging.getLogger(__name__)
+_DEFAULT_PAGE_SIZE = 50
+_PAGE_SIZE_ERROR_SUBSTRING = "page size must be less than or equal to 50"
+_TOKEN_EXPIRY_SAFETY_WINDOW = 60  # seconds
+
+
+class GooglePhotosAPIError(RuntimeError):
+    """Raised when the Google Photos API returns an error response."""
+
+
+@dataclass
+class _TokenCache:
+    access_token: str
+    expires_at: float
+
+    def is_valid(self, now: float) -> bool:
+        return bool(self.access_token) and now + _TOKEN_EXPIRY_SAFETY_WINDOW < self.expires_at
+
+
+class GooglePhotosClient:
+    """Client capable of fetching media items and albums from Google Photos."""
+
+    def __init__(
+        self,
+        settings: GooglePhotosSettings,
+        *,
+        session: Optional[requests.Session] = None,
+        clock=time.time,
+    ) -> None:
+        self._settings = settings
+        self._session = session or requests.Session()
+        self._clock = clock
+        self._token_cache: Optional[_TokenCache] = None
+
+    @classmethod
+    def from_environment(cls) -> "GooglePhotosClient":
+        return cls(load_google_photos_settings())
+
+    @property
+    def settings(self) -> GooglePhotosSettings:
+        return self._settings
+
+    def list_media_items(self, album_id: str) -> List[Dict]:
+        """Return all media items for the specified album."""
+
+        if not album_id:
+            raise GooglePhotosAPIError("An album id is required to call mediaItems.search")
+
+        media_items: List[Dict] = []
+        page_token: Optional[str] = None
+        use_page_size = True
+
+        while True:
+            payload: Dict[str, object] = {"albumId": album_id}
+            if use_page_size:
+                payload["pageSize"] = _DEFAULT_PAGE_SIZE
+            if page_token:
+                payload["pageToken"] = page_token
+
+            try:
+                response = self._authenticated_post("/v1/mediaItems:search", json=payload)
+            except GooglePhotosAPIError as exc:
+                if use_page_size and _should_retry_without_page_size(exc):
+                    use_page_size = False
+                    continue
+                raise
+            data = self._extract_json(response)
+
+            items = data.get("mediaItems", []) or []
+            if not isinstance(items, list):
+                raise GooglePhotosAPIError("Unexpected mediaItems payload from Google Photos API")
+            media_items.extend(item for item in items if isinstance(item, dict))
+
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                break
+
+        return media_items
+
+    def list_albums(self) -> List[Dict]:
+        """Return the albums available to the authenticated user."""
+
+        personal_albums = self._list_collection("/v1/albums", "albums")
+        shared_albums = self._list_collection("/v1/sharedAlbums", "sharedAlbums")
+
+        combined: List[Dict] = []
+        seen: set[str] = set()
+
+        for album in personal_albums + shared_albums:
+            if not isinstance(album, dict):
+                continue
+            album_id = album.get("id")
+            if album_id is None:
+                continue
+            identifier = str(album_id).strip()
+            if not identifier or identifier in seen:
+                continue
+            seen.add(identifier)
+            combined.append(album)
+
+        return combined
+
+    # ------------------------------------------------------------------
+    def _authenticated_post(self, path: str, *, json: Dict[str, object]) -> Response:
+        token = self._get_access_token()
+        url = f"{self._settings.api_base_url}{path}"
+        headers = {"Authorization": f"Bearer {token}"}
+
+        try:
+            response = self._session.post(url, json=json, headers=headers, timeout=15)
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise GooglePhotosAPIError("Error calling Google Photos API") from exc
+
+        if response.status_code >= 400:
+            raise GooglePhotosAPIError(
+                f"Google Photos API returned {response.status_code}: {response.text.strip()}"
+            )
+        return response
+
+    def _authenticated_get(self, path: str, *, params: Optional[Dict[str, object]] = None) -> Response:
+        token = self._get_access_token()
+        url = f"{self._settings.api_base_url}{path}"
+        headers = {"Authorization": f"Bearer {token}"}
+
+        try:
+            response = self._session.get(url, params=params, headers=headers, timeout=15)
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise GooglePhotosAPIError("Error calling Google Photos API") from exc
+
+        if response.status_code >= 400:
+            raise GooglePhotosAPIError(
+                f"Google Photos API returned {response.status_code}: {response.text.strip()}"
+            )
+        return response
+
+    def _list_collection(self, path: str, key: str) -> List[Dict]:
+        items: List[Dict] = []
+        page_token: Optional[str] = None
+        use_page_size = True
+
+        while True:
+            params: Dict[str, object] = {}
+            if use_page_size:
+                params["pageSize"] = _DEFAULT_PAGE_SIZE
+            if page_token:
+                params["pageToken"] = page_token
+
+            try:
+                response = self._authenticated_get(path, params=params)
+            except GooglePhotosAPIError as exc:
+                if use_page_size and _should_retry_without_page_size(exc):
+                    use_page_size = False
+                    continue
+                raise
+            data = self._extract_json(response)
+
+            collection = data.get(key, []) or []
+            if not isinstance(collection, list):
+                raise GooglePhotosAPIError(
+                    f"Unexpected {key} payload from Google Photos API"
+                )
+            items.extend(item for item in collection if isinstance(item, dict))
+
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                break
+
+        return items
+
+    def _get_access_token(self) -> str:
+        now = self._clock()
+        if self._token_cache and self._token_cache.is_valid(now):
+            return self._token_cache.access_token
+
+        payload = {
+            "client_id": self._settings.client_id,
+            "client_secret": self._settings.client_secret,
+            "refresh_token": self._settings.refresh_token,
+            "grant_type": "refresh_token",
+        }
+
+        try:
+            response = self._session.post(self._settings.token_url, data=payload, timeout=15)
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise GooglePhotosAPIError("Unable to refresh Google Photos access token") from exc
+
+        if response.status_code >= 400:
+            raise GooglePhotosAPIError(
+                f"Google Photos token endpoint returned {response.status_code}: {response.text.strip()}"
+            )
+
+        data = self._extract_json(response)
+        access_token = data.get("access_token")
+        expires_in = data.get("expires_in")
+        if not access_token or not expires_in:
+            raise GooglePhotosAPIError("Invalid token response from Google OAuth endpoint")
+
+        try:
+            expires_at = now + float(expires_in)
+        except (TypeError, ValueError) as exc:
+            raise GooglePhotosAPIError("Invalid expires_in value in token response") from exc
+
+        self._token_cache = _TokenCache(access_token=access_token, expires_at=expires_at)
+        try:
+            save_tokens(
+                refresh_token=self._settings.refresh_token,
+                access_token=access_token,
+                expires_in=expires_in,
+            )
+        except RuntimeError:
+            # Ignore persistence errors during refresh; callers can continue using
+            # the in-memory token cache and surface storage issues elsewhere.
+            pass
+        return access_token
+
+    def _extract_json(self, response: Response) -> Dict:
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - handled as an error case
+            raise GooglePhotosAPIError("Failed to decode Google Photos response as JSON") from exc
+
+        if not isinstance(payload, dict):
+            raise GooglePhotosAPIError("Unexpected payload returned by Google Photos API")
+        return payload
+
+
+def _should_retry_without_page_size(error: GooglePhotosAPIError) -> bool:
+    message = str(error).lower()
+    return _PAGE_SIZE_ERROR_SUBSTRING in message
+
+
+_client_instance: Optional[GooglePhotosClient] = None
+
+
+def get_google_photos_client() -> GooglePhotosClient:
+    """Return a cached GooglePhotosClient instance."""
+
+    global _client_instance
+    if _client_instance is None:
+        try:
+            _client_instance = GooglePhotosClient.from_environment()
+        except RuntimeError as exc:
+            _LOGGER.warning("Google Photos client is not configured: %s", exc)
+            raise
+    return _client_instance
+
+
+def reset_google_photos_client() -> None:
+    """Clear the cached GooglePhotosClient instance."""
+
+    global _client_instance
+    _client_instance = None

--- a/app/services/google_photos_token_store.py
+++ b/app/services/google_photos_token_store.py
@@ -1,0 +1,258 @@
+"""Persistence helpers for Google Photos OAuth tokens."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from time import time
+from typing import Any, Dict, Optional
+
+_TOKEN_STORE_ENV_VAR = "GOOGLE_PHOTOS_TOKEN_STORE_PATH"
+_DEFAULT_FILENAME = "google_photos_tokens.json"
+_LOCK = Lock()
+
+
+@dataclass(frozen=True)
+class AccessTokenStatus:
+    """Description of the currently stored Google Photos access token."""
+
+    refresh_token_present: bool
+    access_token_present: bool
+    access_token_valid: bool
+    access_token_expires_at: Optional[float]
+
+
+def _candidate_directories():
+    """Yield directories that may contain the token store."""
+
+    root = Path(__file__).resolve().parents[2]
+    yield root / "instance"
+
+    home = Path.home()
+    if home:
+        yield home / ".config" / "wanderlog"
+        yield home / ".wanderlog"
+
+    xdg_state_home = os.getenv("XDG_STATE_HOME")
+    if xdg_state_home:
+        yield Path(xdg_state_home) / "wanderlog"
+
+    xdg_data_home = os.getenv("XDG_DATA_HOME")
+    if xdg_data_home:
+        yield Path(xdg_data_home) / "wanderlog"
+
+    yield Path.cwd()
+
+
+def _resolve_store_path() -> Path:
+    """Return the file path used to persist Google Photos tokens."""
+
+    override = os.getenv(_TOKEN_STORE_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+
+    for directory in _candidate_directories():
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+
+        if os.access(directory, os.W_OK):
+            return directory / _DEFAULT_FILENAME
+
+    temp_directory = _resolve_temp_directory()
+    if temp_directory is not None:
+        return temp_directory / _DEFAULT_FILENAME
+
+    raise RuntimeError(
+        "Unable to locate a writable directory for the Google Photos token store. "
+        "Set GOOGLE_PHOTOS_TOKEN_STORE_PATH to a writable location and retry."
+    )
+
+
+def _resolve_temp_directory() -> Optional[Path]:
+    """Return a writable temporary directory for the token store if available."""
+
+    temp_root = Path(tempfile.gettempdir())
+    candidate = temp_root / "wanderlog"
+
+    try:
+        candidate.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    if os.access(candidate, os.W_OK):
+        return candidate
+
+    return None
+
+
+def get_token_store_path() -> Path:
+    """Expose the resolved path for diagnostics and documentation."""
+
+    return _resolve_store_path()
+
+
+def load_tokens() -> Dict[str, Any]:
+    """Return the persisted token payload, if present."""
+
+    try:
+        path = _resolve_store_path()
+    except RuntimeError:
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError, json.JSONDecodeError):
+        # Treat unreadable or malformed payloads as missing.
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    return data
+
+
+def load_refresh_token() -> Optional[str]:
+    """Return the stored refresh token, if available."""
+
+    data = load_tokens()
+    refresh_token = data.get("refresh_token")
+    if isinstance(refresh_token, str):
+        refresh_token = refresh_token.strip()
+        if refresh_token:
+            return refresh_token
+    return None
+
+
+def save_tokens(
+    *,
+    refresh_token: str,
+    access_token: Optional[str] = None,
+    expires_in: Optional[float] = None,
+    token_payload: Optional[Dict[str, Any]] = None,
+    clock=time,
+) -> Dict[str, Any]:
+    """Persist Google OAuth tokens to disk.
+
+    The refresh token is required so the backend can request fresh access tokens
+    as needed. The access token and expiry are stored for observability only.
+    """
+
+    if not refresh_token:
+        raise ValueError("refresh_token is required to persist Google Photos tokens")
+
+    expires_at: Optional[float] = None
+    if expires_in is not None:
+        try:
+            expires_at = float(expires_in) + float(clock())
+        except (TypeError, ValueError):
+            expires_at = None
+
+    payload: Dict[str, Any] = {
+        "refresh_token": refresh_token,
+        "access_token": access_token,
+        "expires_at": expires_at,
+    }
+    if token_payload is not None:
+        payload["token_payload"] = token_payload
+
+    path = _resolve_store_path()
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            "Unable to create the Google Photos token directory. Set "
+            "GOOGLE_PHOTOS_TOKEN_STORE_PATH to a writable location and retry."
+        ) from exc
+
+    serialisable_payload = payload
+
+    try:
+        with _LOCK:
+            with path.open("w", encoding="utf-8") as handle:
+                json.dump(serialisable_payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+    except OSError as exc:
+        raise RuntimeError(
+            "Unable to write the Google Photos token file at "
+            f"{path}. Set GOOGLE_PHOTOS_TOKEN_STORE_PATH to a writable "
+            "location and retry."
+        ) from exc
+
+    return payload
+
+
+def clear_tokens() -> bool:
+    """Remove the persisted token payload, if present."""
+
+    path = _resolve_store_path()
+
+    with _LOCK:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise RuntimeError(
+                "Unable to delete the Google Photos token file at "
+                f"{path}. Set GOOGLE_PHOTOS_TOKEN_STORE_PATH to a writable "
+                "location and retry."
+            ) from exc
+
+    return True
+
+
+def get_access_token_status(*, clock=time) -> AccessTokenStatus:
+    """Return information about the stored access token and its expiry."""
+
+    data = load_tokens()
+
+    refresh_token = data.get("refresh_token")
+    refresh_token_present = isinstance(refresh_token, str) and bool(refresh_token.strip())
+
+    access_token = data.get("access_token")
+    access_token_present = isinstance(access_token, str) and bool(access_token.strip())
+
+    expires_at_raw = data.get("expires_at")
+    expires_at: Optional[float] = None
+    if expires_at_raw is not None:
+        try:
+            expires_at = float(expires_at_raw)
+        except (TypeError, ValueError):
+            expires_at = None
+
+    now: Optional[float]
+    try:
+        now = float(clock())
+    except (TypeError, ValueError):
+        now = None
+
+    access_token_valid = False
+    if access_token_present and expires_at is not None and now is not None:
+        access_token_valid = now < expires_at
+
+    return AccessTokenStatus(
+        refresh_token_present=refresh_token_present,
+        access_token_present=access_token_present,
+        access_token_valid=access_token_valid,
+        access_token_expires_at=expires_at,
+    )
+
+
+__all__ = [
+    "AccessTokenStatus",
+    "clear_tokens",
+    "get_access_token_status",
+    "get_token_store_path",
+    "load_refresh_token",
+    "load_tokens",
+    "save_tokens",
+]

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -708,6 +708,102 @@ button, input, select { font-family: inherit; }
     color: #6b7280;
 }
 
+.trip-photos-album-group {
+    margin-top: 8px;
+}
+
+.trip-photos-album-picker {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+}
+
+.trip-photos-album-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid #1a73e8;
+    background-color: #1a73e8;
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.trip-photos-album-button:hover,
+.trip-photos-album-button:focus-visible {
+    background-color: #0c57c9;
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.25);
+    outline: none;
+    transform: translateY(-1px);
+}
+
+.trip-photos-album-button:disabled,
+.trip-photos-album-button[disabled] {
+    cursor: not-allowed;
+    background-color: rgba(26, 115, 232, 0.35);
+    border-color: rgba(26, 115, 232, 0.35);
+    box-shadow: none;
+    transform: none;
+}
+
+.trip-photos-album-summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 9px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(60, 64, 67, 0.16);
+    background: rgba(248, 250, 252, 0.95);
+}
+
+.trip-photos-album-summary-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.trip-photos-album-summary-text span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.trip-photos-album-count {
+    color: #5f6368;
+    font-size: 12px;
+}
+
+.trip-photos-album-clear {
+    background: transparent;
+    border: none;
+    color: #1a73e8;
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+    padding: 0;
+    transition: color 0.2s ease;
+}
+
+.trip-photos-album-clear:hover,
+.trip-photos-album-clear:focus-visible {
+    color: #0c57c9;
+    text-decoration: underline;
+    outline: none;
+}
+
+.trip-photos-album-clear:disabled {
+    cursor: not-allowed;
+    color: rgba(95, 99, 104, 0.5);
+    text-decoration: none;
+}
+
 .trip-profile-description textarea:focus {
     outline: none;
     border-color: #111827;
@@ -717,6 +813,89 @@ button, input, select { font-family: inherit; }
 .trip-profile-description textarea:disabled {
     opacity: 0.7;
     cursor: not-allowed;
+}
+
+.modal-content-large {
+    width: min(90vw, 640px);
+}
+
+.google-photos-album-list {
+    margin-top: 16px;
+    max-height: 360px;
+    overflow-y: auto;
+    display: grid;
+    gap: 12px;
+}
+
+.google-photos-album-item {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    background: rgba(248, 250, 252, 0.95);
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.google-photos-album-item:hover,
+.google-photos-album-item:focus-visible,
+.google-photos-album-item[aria-selected="true"] {
+    border-color: #1a73e8;
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.2);
+    outline: none;
+    transform: translateY(-1px);
+}
+
+.google-photos-album-cover {
+    width: 64px;
+    height: 64px;
+    border-radius: 10px;
+    object-fit: cover;
+    background: #eceff1;
+    flex-shrink: 0;
+}
+
+.google-photos-album-cover-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #5f6368;
+    font-size: 11px;
+    text-align: center;
+    padding: 4px;
+}
+
+.google-photos-album-details {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+    text-align: left;
+}
+
+.google-photos-album-title {
+    font-weight: 600;
+    color: #202124;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.google-photos-album-meta {
+    font-size: 13px;
+    color: #5f6368;
+}
+
+.google-photos-album-error {
+    margin-top: 16px;
+    color: #b00020;
+}
+
+.google-photos-album-empty {
+    margin-top: 16px;
+    color: #5f6368;
 }
 
 .trip-profile-description-footer {
@@ -1192,6 +1371,25 @@ button, input, select { font-family: inherit; }
                     text-align: right;
                     width: 100%; }
 
+.overlay-button-google { display: flex;
+                         align-items: center;
+                         justify-content: center;
+                         gap: 8px;
+                         font-weight: 600;
+                         background: #1a73e8;
+                         color: #fff;
+                         box-shadow: 0 12px 24px rgba(26, 115, 232, 0.25); }
+
+.overlay-button-google:hover,
+.overlay-button-google:focus-visible { background: #0c57c9;
+                                       color: #fff; }
+
+.overlay-button-google:disabled,
+.overlay-button-google[disabled] { background: rgba(26,115,232,0.35);
+                                   color: rgba(255,255,255,0.75);
+                                   cursor: not-allowed;
+                                   box-shadow: none; }
+
 .overlay-section-title { align-self: stretch;
                          padding-top: 3px;
                          font-size: 13px;
@@ -1200,6 +1398,15 @@ button, input, select { font-family: inherit; }
                          text-transform: uppercase;
                          color: #444;
                          text-align: right; }
+
+.overlay-helper-text {   margin: 8px 0 16px;
+                         font-size: 13px;
+                         line-height: 1.6;
+                         color: #5c6470;
+                         text-align: right; }
+
+.overlay-helper-text-success { color: #0f7a49; }
+.overlay-helper-text-warning { color: #b45309; }
 
 .overlay-button:hover {     background: rgba(255,255,255,1);
                             transform: translateY(-2px);

--- a/app/templates/google_photos_oauth_result.html
+++ b/app/templates/google_photos_oauth_result.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Google Photos Authorization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+        body {
+            font-family: "Raleway", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            margin: 0;
+            padding: 2.5rem 1.25rem;
+            background: #f4f5f8;
+            color: #1c1f26;
+        }
+        main {
+            max-width: 720px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 16px;
+            padding: 2.5rem;
+            box-shadow: 0 20px 40px rgba(31, 41, 55, 0.08);
+        }
+        h1 {
+            margin-top: 0;
+            font-size: 2rem;
+            letter-spacing: -0.03em;
+        }
+        .status {
+            border-radius: 12px;
+            padding: 1.25rem;
+            margin-bottom: 2rem;
+            background: #eef6ff;
+            color: #1c3d5a;
+            border: 1px solid rgba(52, 120, 246, 0.2);
+        }
+        .status.error {
+            background: #fdecec;
+            color: #641e16;
+            border-color: rgba(220, 53, 69, 0.25);
+        }
+        code {
+            font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.95rem;
+            background: rgba(15, 23, 42, 0.08);
+            border-radius: 6px;
+            padding: 0.2rem 0.4rem;
+        }
+        pre {
+            background: rgba(15, 23, 42, 0.06);
+            padding: 1rem;
+            border-radius: 12px;
+            overflow-x: auto;
+            font-size: 0.9rem;
+            line-height: 1.45;
+        }
+        dl {
+            margin: 0 0 2rem;
+            display: grid;
+            grid-template-columns: minmax(160px, 200px) 1fr;
+            gap: 0.5rem 1rem;
+        }
+        dt {
+            font-weight: 600;
+            color: #3a4459;
+        }
+        dd {
+            margin: 0;
+            word-break: break-all;
+        }
+        a.button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            background: #3478f6;
+            color: #fff;
+            padding: 0.75rem 1.5rem;
+            border-radius: 999px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background 0.2s ease;
+        }
+        a.button:hover,
+        a.button:focus {
+            background: #255fcb;
+        }
+        p {
+            line-height: 1.6;
+            margin-top: 0;
+        }
+        ul {
+            margin: 1rem 0 2rem;
+            padding-left: 1.5rem;
+        }
+        li + li {
+            margin-top: 0.25rem;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <h1>Google Photos authorization</h1>
+        {% if error %}
+        <div class="status error" role="alert">
+            <strong>Authorization failed:</strong>
+            <p>{{ error }}</p>
+            {% if exception %}<p><code>{{ exception }}</code></p>{% endif %}
+        </div>
+        <p>Return to WanderLog and try the sign-in flow again after resolving the issue above.</p>
+        {% else %}
+        <div class="status" role="status" aria-live="polite">
+            <strong>Success!</strong>
+            <p>WanderLog saved your Google Photos credentials and will reuse them automatically.</p>
+        </div>
+        {% if token_store_path %}
+        <p>The connection details are stored at <code>{{ token_store_path }}</code>. Keep this file safe.</p>
+        {% endif %}
+        <dl>
+            {% if refresh_token %}
+            <dt>Refresh token</dt>
+            <dd><code>{{ refresh_token }}</code></dd>
+            {% endif %}
+            {% if access_token %}
+            <dt>Access token</dt>
+            <dd><code>{{ access_token }}</code></dd>
+            {% endif %}
+        </dl>
+        <p>You can close this tab and return to WanderLog—the "Sign in with Google" button should now show as connected.</p>
+        {% if token_payload %}
+        <p>The full token response from Google is shown below for reference:</p>
+        <pre>{{ token_payload | tojson(indent=2) }}</pre>
+        {% endif %}
+        {% endif %}
+        <p><a class="button" href="{{ url_for('main.index') }}">Back to WanderLog</a></p>
+    </main>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,6 +38,16 @@
                 <button class="overlay-button" type="button" id="refreshMapButton">Refresh Map</button>
                 <button class="overlay-button" type="button" id="viewArchivedPointsButton">View Archived Points</button>
                 <button class="overlay-button" type="button" id="manageModeToggle" data-manage-mode-toggle data-manage-mode-active-class="overlay-button-active" data-manage-mode-label-default="Enter Manage Mode" data-manage-mode-label-active="Exit Manage Mode">Enter Manage Mode</button>
+                {% if google_photos_auth_config.enabled %}
+                <h2 class="overlay-section-title" id="googlePhotosTitle">Google Photos</h2>
+                <div class="google-photos-controls">
+                    <button class="overlay-button overlay-button-google" type="button" id="googlePhotosSignInButton" {% if google_photos_connected %}hidden{% endif %}>Sign in with Google</button>
+                    <button class="overlay-button" type="button" id="googlePhotosSignOutButton" {% if not google_photos_connected %}hidden{% endif %}>Disconnect Google Photos</button>
+                    <p class="overlay-helper-text overlay-helper-text-success" id="googlePhotosConnectedMessage" aria-live="polite" {% if not google_photos_connected %}hidden{% endif %}>Google Photos is connected. Shared album images will appear on your trips automatically.</p>
+                    <p class="overlay-helper-text" id="googlePhotosHelperText" {% if google_photos_connected %}hidden{% endif %}>Authorize WanderLog to access the shared Google Photos album tied to your journeys.</p>
+                    <p class="overlay-helper-text overlay-helper-text-success" id="googlePhotosTokenStatus" hidden aria-live="polite"></p>
+                </div>
+                {% endif %}
                 <h2 class="overlay-section-title" id="filtersTitle">Filters</h2>
                 <div id="sourceTypeFilters" class="checkbox-group" role="group" aria-labelledby="filtersTitle"></div>
                 <h2 class="overlay-section-title" id="dateFiltersTitle">Date Range</h2>
@@ -237,6 +247,19 @@
             </div>
         </div>
     </div>
+    <div id="googlePhotosAlbumModal" class="modal-overlay" aria-hidden="true" hidden>
+        <div class="modal-content modal-content-large" role="dialog" aria-modal="true" aria-labelledby="googlePhotosAlbumModalTitle" tabindex="-1">
+            <h2 id="googlePhotosAlbumModalTitle">Select Google Photos album</h2>
+            <p id="googlePhotosAlbumModalDescription" class="modal-description">Choose an album to link with this trip.</p>
+            <div id="googlePhotosAlbumStatus" class="modal-status" role="status" aria-live="polite" hidden></div>
+            <div id="googlePhotosAlbumError" class="google-photos-album-error" role="alert" hidden></div>
+            <div id="googlePhotosAlbumEmpty" class="google-photos-album-empty" hidden>No albums were found in your Google Photos library.</div>
+            <div id="googlePhotosAlbumList" class="google-photos-album-list" role="listbox" aria-labelledby="googlePhotosAlbumModalTitle"></div>
+            <div class="modal-actions">
+                <button type="button" class="modal-button secondary" id="googlePhotosAlbumCancel">Cancel</button>
+            </div>
+        </div>
+    </div>
     <div id="tripProfileOverlay" class="trip-profile-overlay" aria-hidden="true" hidden>
         <article id="tripProfilePanel" class="trip-profile-panel" role="dialog" aria-modal="false" aria-labelledby="tripDetailTitle">
             <div id="tripDetailView" class="trip-detail trip-profile-content" hidden aria-hidden="true">
@@ -283,6 +306,20 @@
                         <label class="trip-profile-description-label" for="tripPhotosInput">Google Photos album link</label>
                         <input type="url" id="tripPhotosInput" name="google_photos_url" placeholder="https://photos.app.goo.gl/" autocomplete="off">
                         <p class="trip-profile-helper-text">Paste a shared Google Photos album link to display images for this trip.</p>
+                    </div>
+                    <div class="trip-profile-input-group trip-photos-album-group">
+                        <span class="trip-profile-description-label">Link a Google Photos album</span>
+                        <div class="trip-photos-album-picker">
+                            <button type="button" class="trip-photos-album-button" id="tripPhotosAlbumSelect">Choose album</button>
+                            <div class="trip-photos-album-summary" id="tripPhotosAlbumSummary" hidden>
+                                <div class="trip-photos-album-summary-text">
+                                    <span id="tripPhotosAlbumTitle"></span>
+                                    <span id="tripPhotosAlbumCount" class="trip-photos-album-count" hidden></span>
+                                </div>
+                                <button type="button" class="trip-photos-album-clear" id="tripPhotosAlbumClear">Remove</button>
+                            </div>
+                        </div>
+                        <p class="trip-profile-helper-text" id="tripPhotosAlbumHelper">Select an album from your Google Photos library to automatically load pictures for this trip.</p>
                     </div>
                     <div class="trip-profile-description-footer">
                         <div class="trip-profile-updated" id="tripDescriptionUpdated" hidden>
@@ -336,6 +373,13 @@
             google_timeline: "{{ url_for('static', filename='assets/marker-pin-blue.svg') }}",
             manual: "{{ url_for('static', filename='assets/marker-pin-orange.svg') }}",
             default: "{{ url_for('static', filename='assets/marker-pin-gray.svg') }}",
+        },
+        googlePhotosAuth: {
+            enabled: {{ google_photos_auth_config.enabled | tojson }},
+            startUrl: {{ google_photos_auth_config.start_url | tojson }},
+            logoutUrl: {{ google_photos_auth_config.logout_url | tojson }},
+            statusUrl: {{ google_photos_auth_config.status_url | tojson }},
+            connected: {{ google_photos_connected | tojson }},
         },
     };
 </script>

--- a/app/trip_store.py
+++ b/app/trip_store.py
@@ -34,6 +34,9 @@ class Trip:
     place_ids: List[str] = field(default_factory=list)
     description: str = ""
     google_photos_url: str = ""
+    google_photos_album_id: str = ""
+    google_photos_album_title: str = ""
+    google_photos_product_url: str = ""
     created_at: str = field(default_factory=_utcnow_iso)
     updated_at: str = field(default_factory=_utcnow_iso)
 
@@ -82,6 +85,24 @@ def _normalise_trip_data(raw: dict) -> Optional[Trip]:
         photos_candidate = str(photos_raw)
         google_photos_url = photos_candidate.strip()
 
+    album_id_raw = raw.get("google_photos_album_id") or raw.get("photos_album_id")
+    if album_id_raw is None:
+        google_photos_album_id = ""
+    else:
+        google_photos_album_id = str(album_id_raw).strip()
+
+    album_title_raw = raw.get("google_photos_album_title") or raw.get("photos_album_title")
+    if album_title_raw is None:
+        google_photos_album_title = ""
+    else:
+        google_photos_album_title = str(album_title_raw).strip()
+
+    product_url_raw = raw.get("google_photos_product_url") or raw.get("photos_product_url")
+    if product_url_raw is None:
+        google_photos_product_url = ""
+    else:
+        google_photos_product_url = str(product_url_raw).strip()
+
     created_at = str(raw.get("created_at") or raw.get("created") or "").strip()
     if not created_at:
         created_at = _utcnow_iso()
@@ -98,6 +119,9 @@ def _normalise_trip_data(raw: dict) -> Optional[Trip]:
         updated_at=updated_at,
         description=description,
         google_photos_url=google_photos_url,
+        google_photos_album_id=google_photos_album_id,
+        google_photos_album_title=google_photos_album_title,
+        google_photos_product_url=google_photos_product_url,
     )
 
 
@@ -172,6 +196,9 @@ def create_trip(
     *,
     description: str = "",
     google_photos_url: str = "",
+    google_photos_album_id: str = "",
+    google_photos_album_title: str = "",
+    google_photos_product_url: str = "",
 ) -> Trip:
     """Create a new trip with ``name`` and persist it."""
 
@@ -185,6 +212,10 @@ def create_trip(
     raw_photos_url = str(google_photos_url or "")
     cleaned_photos_url = raw_photos_url.strip()
 
+    cleaned_album_id = str(google_photos_album_id or "").strip()
+    cleaned_album_title = str(google_photos_album_title or "").strip()
+    cleaned_product_url = str(google_photos_product_url or "").strip()
+
     _ensure_cache()
 
     trip = Trip(
@@ -192,6 +223,9 @@ def create_trip(
         name=cleaned_name,
         description=cleaned_description,
         google_photos_url=cleaned_photos_url,
+        google_photos_album_id=cleaned_album_id,
+        google_photos_album_title=cleaned_album_title,
+        google_photos_product_url=cleaned_product_url,
     )
     _trips_cache.append(trip)
     save_trips()
@@ -350,6 +384,9 @@ def update_trip_metadata(
     name: Optional[str] = None,
     description: Optional[str] = None,
     google_photos_url: Optional[str] = None,
+    google_photos_album_id: Optional[str] = None,
+    google_photos_album_title: Optional[str] = None,
+    google_photos_product_url: Optional[str] = None,
 ) -> Trip:
     """Update metadata for the trip identified by ``trip_id``."""
 
@@ -379,6 +416,27 @@ def update_trip_metadata(
         final_photos_url = raw_photos_url.strip()
         if final_photos_url != trip.google_photos_url:
             trip.google_photos_url = final_photos_url
+            updated = True
+
+    if google_photos_album_id is not None:
+        raw_album_id = str(google_photos_album_id or "")
+        final_album_id = raw_album_id.strip()
+        if final_album_id != trip.google_photos_album_id:
+            trip.google_photos_album_id = final_album_id
+            updated = True
+
+    if google_photos_album_title is not None:
+        raw_title = str(google_photos_album_title or "")
+        final_title = raw_title.strip()
+        if final_title != trip.google_photos_album_title:
+            trip.google_photos_album_title = final_title
+            updated = True
+
+    if google_photos_product_url is not None:
+        raw_product_url = str(google_photos_product_url or "")
+        final_product_url = raw_product_url.strip()
+        if final_product_url != trip.google_photos_product_url:
+            trip.google_photos_product_url = final_product_url
             updated = True
 
     if updated:

--- a/app/utils/google_photos.py
+++ b/app/utils/google_photos.py
@@ -2,21 +2,27 @@
 
 from __future__ import annotations
 
-import re
+import logging
 import time
-from html import unescape
-from typing import Dict, List
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from typing import Dict, Iterable, List, Optional
 
+from app.services.google_photos_api import (
+    GooglePhotosAPIError,
+    GooglePhotosClient,
+    get_google_photos_client,
+)
+
+_LOGGER = logging.getLogger(__name__)
 _CACHE_TTL_SECONDS = 3600
 _DEFAULT_MAX_IMAGES = 50
-_USER_AGENT = (
-    "Mozilla/5.0 (compatible; WanderLog/1.0; +https://github.com/)"
-)
+_PREFERRED_WIDTH = 2048
+_AVATAR_KEYWORDS = ("avatar", "profile", "userphoto", "contacts")
 
 _CacheEntry = tuple[float, List[str]]
 _CACHE: Dict[str, _CacheEntry] = {}
+_AlbumCacheEntry = tuple[float, List[Dict[str, object]]]
+_ALBUM_CACHE: Optional[_AlbumCacheEntry] = None
+_ALBUM_CACHE_TTL_SECONDS = 900
 
 
 def _clean_url(url: str) -> str:
@@ -25,85 +31,192 @@ def _clean_url(url: str) -> str:
     return url.strip()
 
 
-def _fetch_html(url: str) -> str:
+def _extract_album_token(url: str) -> Optional[str]:
     if not url:
+        return None
+    cleaned = url.rstrip("/")
+    token = cleaned.split("/")[-1]
+    return token or None
+
+
+def _normalise_resolution(base_url: str) -> str:
+    if not base_url:
         return ""
-
-    request = Request(url, headers={"User-Agent": _USER_AGENT})
-    try:
-        with urlopen(request, timeout=15) as response:  # nosec: trusted domain
-            content_bytes = response.read()
-    except (HTTPError, URLError, TimeoutError):
-        return ""
-    except Exception:
-        return ""
-
-    try:
-        return content_bytes.decode("utf-8", errors="replace")
-    except Exception:
-        return ""
+    if base_url.endswith("="):
+        base_url = base_url[:-1]
+    if "=" in base_url:
+        # Replace any existing size directives to request the preferred width.
+        prefix, _ = base_url.split("=", 1)
+        return f"{prefix}=w{_PREFERRED_WIDTH}"
+    return f"{base_url}=w{_PREFERRED_WIDTH}"
 
 
-def _normalise_resolution(url: str) -> str:
-    if not url:
-        return ""
+def _is_avatar(item: Dict, url: str) -> bool:
+    filename = str(item.get("filename", "")).lower()
+    description = str(item.get("description", "")).lower()
+    metadata = item.get("mediaMetadata", {}) or {}
+    photo_meta = metadata.get("photo", {}) or {}
+    camera_model = str(photo_meta.get("cameraModel", "")).lower()
 
-    updated = re.sub(r"=w\d+", "=w2048", url)
-    updated = re.sub(r"-w\d+", "-w2048", updated)
-    updated = re.sub(r"-h\d+", "-h2048", updated)
-    updated = re.sub(r"=s\d+", "=s2048", updated)
-    if "=" not in updated:
-        updated = f"{updated}=w2048"
-    return updated
+    searchable_values: Iterable[str] = (filename, description, camera_model, url.lower())
+    return any(keyword in value for value in searchable_values for keyword in _AVATAR_KEYWORDS)
 
 
-def _extract_image_urls(html: str, *, max_images: int) -> List[str]:
-    if not html:
-        return []
+def _is_supported_image(item: Dict) -> bool:
+    mime_type = str(item.get("mimeType", "")).lower()
+    return mime_type.startswith("image/")
 
-    normalised = unescape(html)
-    normalised = (
-        normalised
-        .replace("\\u003d", "=")
-        .replace("\\u0026", "&")
-        .replace("\\u002f", "/")
-    )
 
-    pattern = re.compile(r"(?:https?:)?//lh3\.googleusercontent\.com/[^\s\"']+")
-    matches = pattern.findall(normalised)
-
-    results: List[str] = []
-    seen_bases = set()
-    for match in matches:
-        candidate = match.split("\\")[0]
-        candidate = candidate.split('"')[0]
-        if candidate.startswith("//"):
-            candidate = f"https:{candidate}"
-        base = candidate.split("=")[0]
-        if base in seen_bases:
+def _translate_media_items(items: Iterable[Dict], *, max_images: int) -> List[str]:
+    images: List[str] = []
+    for item in items:
+        if not isinstance(item, dict):
             continue
-        seen_bases.add(base)
-        results.append(_normalise_resolution(candidate))
-        if len(results) >= max_images:
+        if not _is_supported_image(item):
+            continue
+
+        base_url = str(item.get("baseUrl", ""))
+        if not base_url:
+            continue
+
+        full_url = _normalise_resolution(base_url)
+        if not full_url or _is_avatar(item, full_url):
+            continue
+
+        images.append(full_url)
+        if len(images) >= max_images:
             break
 
-    return results
+    return images
 
 
-def fetch_album_images(url: str, *, max_images: int = _DEFAULT_MAX_IMAGES) -> List[str]:
-    """Return a list of high-resolution image URLs for a shared album."""
-
-    cleaned_url = _clean_url(url)
-    if not cleaned_url:
+def _fetch_media_items(client: GooglePhotosClient, album_id: str) -> List[Dict]:
+    try:
+        return client.list_media_items(album_id)
+    except GooglePhotosAPIError as exc:
+        _LOGGER.warning("Failed to load Google Photos album: %s", exc)
         return []
 
-    cache_entry = _CACHE.get(cleaned_url)
+
+def fetch_album_images(
+    url: str = "",
+    *,
+    album_id: Optional[str] = None,
+    max_images: int = _DEFAULT_MAX_IMAGES,
+) -> List[str]:
+    """Return a list of high-resolution image URLs for a Google Photos album."""
+
+    cleaned_url = _clean_url(url)
+    cleaned_album_id = album_id.strip() if isinstance(album_id, str) else ""
+
+    if not cleaned_url and not cleaned_album_id:
+        return []
+
+    cache_key = f"id:{cleaned_album_id}" if cleaned_album_id else cleaned_url
+
     now = time.time()
+    cache_entry = _CACHE.get(cache_key)
     if cache_entry and now - cache_entry[0] < _CACHE_TTL_SECONDS:
         return list(cache_entry[1])
 
-    html = _fetch_html(cleaned_url)
-    images = _extract_image_urls(html, max_images=max_images)
+    try:
+        client = get_google_photos_client()
+    except RuntimeError:
+        _LOGGER.info("Google Photos client is not configured; skipping fetch")
+        return []
 
-    _CACHE[cleaned_url] = (now, images)
+    resolved_album_id = cleaned_album_id or client.settings.shared_album_id or _extract_album_token(cleaned_url)
+    if not resolved_album_id:
+        _LOGGER.warning("No album identifier is configured or present in the request")
+        return []
+
+    media_items = _fetch_media_items(client, resolved_album_id)
+    images = _translate_media_items(media_items, max_images=max_images)
+
+    _CACHE[cache_key] = (now, images)
     return list(images)
+
+
+def _normalise_album_entry(entry: Dict) -> Optional[Dict[str, object]]:
+    if not isinstance(entry, dict):
+        return None
+
+    album_id_raw = entry.get("id")
+    album_id = str(album_id_raw or "").strip()
+    if not album_id:
+        return None
+
+    title_raw = entry.get("title")
+    title = str(title_raw or "").strip()
+    product_url_raw = entry.get("productUrl")
+    product_url = str(product_url_raw or "").strip()
+
+    share_info = entry.get("shareInfo") or {}
+    shareable_url = ""
+    if isinstance(share_info, dict):
+        shareable_url = str(share_info.get("shareableUrl") or "").strip()
+
+    cover_photo_base = str(entry.get("coverPhotoBaseUrl") or "").strip()
+    cover_photo_url = _normalise_resolution(cover_photo_base) if cover_photo_base else ""
+
+    media_items_raw = entry.get("mediaItemsCount")
+    media_items_count = 0
+    if media_items_raw is not None:
+        try:
+            media_items_count = int(media_items_raw)
+        except (TypeError, ValueError):
+            media_items_count = 0
+
+    is_writeable = bool(entry.get("isWriteable"))
+
+    if not product_url and shareable_url:
+        product_url = shareable_url
+
+    return {
+        "id": album_id,
+        "title": title or "Untitled album",
+        "product_url": product_url,
+        "cover_photo_url": cover_photo_url,
+        "media_items_count": media_items_count,
+        "is_writeable": is_writeable,
+        "shareable_url": shareable_url,
+    }
+
+
+def list_google_photos_albums(*, force_refresh: bool = False) -> List[Dict[str, object]]:
+    """Return the albums available to the configured Google Photos client."""
+
+    global _ALBUM_CACHE
+
+    now = time.time()
+    if not force_refresh and _ALBUM_CACHE and now - _ALBUM_CACHE[0] < _ALBUM_CACHE_TTL_SECONDS:
+        cached_albums = _ALBUM_CACHE[1]
+        return [dict(album) for album in cached_albums]
+
+    try:
+        client = get_google_photos_client()
+    except RuntimeError as exc:
+        raise RuntimeError("Google Photos is not connected.") from exc
+
+    try:
+        raw_albums = client.list_albums()
+    except GooglePhotosAPIError as exc:
+        _LOGGER.warning("Failed to list Google Photos albums: %s", exc)
+        raise
+
+    seen: set[str] = set()
+    normalised: List[Dict[str, object]] = []
+
+    for entry in raw_albums:
+        album = _normalise_album_entry(entry)
+        if not album:
+            continue
+        identifier = str(album.get("id") or "").strip()
+        if not identifier or identifier in seen:
+            continue
+        seen.add(identifier)
+        normalised.append(album)
+
+    normalised.sort(key=lambda album: str(album.get("title") or "").lower())
+    _ALBUM_CACHE = (now, normalised)
+    return [dict(album) for album in normalised]

--- a/readme.txt
+++ b/readme.txt
@@ -5,3 +5,17 @@ v0.3 - added dates to map marker popup data.  Made map rendering dynamic, and fa
 v0.4 - updated UI, added data type filtering, cleaned up code
 v0.5 - added archiving/deleting of data points, backups for timeline data on clear map, warnings for clear map & deleting of data points, and date range filtering
 v0.6 - added "Trips" prototype, added edit mode with multi-selection/editing of data points, updates to UI, fixed sorting, added descriptions to Trips
+v0.7 - switched Google Photos ingestion to the official API. Configure GOOGLE_PHOTOS_CLIENT_ID, GOOGLE_PHOTOS_CLIENT_SECRET, GOOGLE_PHOTOS_REFRESH_TOKEN, and GOOGLE_PHOTOS_SHARED_ALBUM_ID environment variables before running the server.
+v0.8 - added an in-app "Sign in with Google" button that completes the Photos Library OAuth consent flow and stores the resulting refresh token for you.
+v0.9 - added an in-app disconnect option plus token status checks so you can manage Google Photos access without editing environment variables.
+
+## Google Photos OAuth setup
+
+1. Create a Google Cloud project, enable the Photos Library API, and configure an OAuth client of type "Web application" with the redirect URI `http://localhost:5000/auth/google/callback` (for production deployments, register the appropriate HTTPS domain instead). The WanderLog consent flow requests both the read-only and sharing scopes so it can list personal and shared albums.
+2. Set the ``GOOGLE_PHOTOS_CLIENT_ID`` and ``GOOGLE_PHOTOS_CLIENT_SECRET`` environment variables before starting WanderLog so the "Sign in with Google" button is enabled in the Settings menu. Launch the app (`python run.py`) and click the button to begin the consent flow.
+3. After you approve access on Google's consent screen, WanderLog stores the refresh token automatically (by default under ``instance/google_photos_tokens.json`` or, if that directory is not writable, in a per-user config folder such as ``~/.config/wanderlog/google_photos_tokens.json`` or a temporary ``wanderlog`` directory created under your system's temp folder) and shows you the raw payload for reference. You do not need to edit your environment.
+4. Restart WanderLog with the client ID/secret still in place (and optionally configure ``GOOGLE_PHOTOS_SHARED_ALBUM_ID`` to point at a single shared album). The server will reuse the saved refresh token whenever it needs a new access token and will keep the stored expiry updated.
+
+Need to revoke access later? Open the Settings panel and click **Disconnect Google Photos** to remove the stored refresh token and clear the in-memory credentials. The status text beneath the Google Photos section reports whether the latest access token is still valid.
+
+You can still run the standalone helper script (``python -m app.scripts.google_photos_oauth``) if you prefer completing the consent flow outside the UI; both approaches populate the same token store. Override ``GOOGLE_PHOTOS_TOKEN_STORE_PATH`` to customise the storage location.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.0
 folium==0.15.0
 pandas==2.1.4
 python-dotenv==1.0.0
+requests==2.31.0
+pytest==7.4.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_google_photos.py
+++ b/tests/test_google_photos.py
@@ -1,0 +1,459 @@
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import app.routes as routes
+from app import create_app
+from app.config import DEFAULT_GOOGLE_PHOTOS_OAUTH_SCOPE, GooglePhotosSettings
+from app.services.google_photos_api import GooglePhotosClient
+from app.services import google_photos_token_store as token_store
+from app.scripts import google_photos_oauth
+from app.utils import google_photos
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = "payload" if text is None else text
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, media_pages, album_pages=None):
+        self.media_pages = list(media_pages)
+        self.album_pages = list(album_pages or [])
+        self.media_call_count = 0
+        self.album_call_count = 0
+        self.token_call_count = 0
+        self.media_requests = []
+        self.album_requests = []
+
+    def post(self, url, json=None, headers=None, data=None, timeout=None):
+        if json is None:
+            self.token_call_count += 1
+            return FakeResponse({"access_token": "token", "expires_in": 3600})
+
+        self.media_requests.append(dict(json) if json is not None else {})
+        if self.media_call_count >= len(self.media_pages):
+            pytest.fail("Unexpected extra mediaItems.search call")
+        payload = self.media_pages[self.media_call_count]
+        self.media_call_count += 1
+        if isinstance(payload, FakeResponse):
+            return payload
+        return FakeResponse(payload)
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.album_requests.append(dict(params) if params is not None else {})
+        if self.album_call_count >= len(self.album_pages):
+            pytest.fail("Unexpected extra list call")
+        payload = self.album_pages[self.album_call_count]
+        self.album_call_count += 1
+        if isinstance(payload, FakeResponse):
+            return payload
+        return FakeResponse(payload)
+
+
+@pytest.fixture
+def token_store_path(tmp_path, monkeypatch):
+    path = tmp_path / "tokens.json"
+    monkeypatch.setenv("GOOGLE_PHOTOS_TOKEN_STORE_PATH", str(path))
+    return path
+
+
+@pytest.fixture
+def app_with_oauth(monkeypatch, token_store_path):
+    monkeypatch.setenv("FLASK_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("GOOGLE_PHOTOS_CLIENT_ID", "client-id")
+    monkeypatch.setenv("GOOGLE_PHOTOS_CLIENT_SECRET", "client-secret")
+
+    app = create_app()
+    app.config.update(TESTING=True, SERVER_NAME="localhost")
+    return app
+
+
+def test_google_photos_client_paginates_until_token_exhausted(token_store_path):
+    pages = [
+        {"mediaItems": [{"id": "1"}], "nextPageToken": "next"},
+        {"mediaItems": [{"id": "2"}, {"id": "3"}]},
+    ]
+    session = FakeSession(pages)
+    settings = GooglePhotosSettings(
+        client_id="id", client_secret="secret", refresh_token="refresh", shared_album_id="album"
+    )
+    client = GooglePhotosClient(settings, session=session, clock=lambda: 0)
+
+    items = client.list_media_items("album")
+
+    assert [item["id"] for item in items] == ["1", "2", "3"]
+    assert session.media_call_count == 2
+    assert session.token_call_count == 1
+
+
+def test_google_photos_client_retries_without_page_size_on_400(token_store_path):
+    error_payload = {"error": {"message": "Page size must be less than or equal to 50."}}
+    pages = [
+        FakeResponse(error_payload, status_code=400, text=json.dumps(error_payload)),
+        {"mediaItems": [{"id": "1"}]},
+    ]
+    session = FakeSession(pages)
+    settings = GooglePhotosSettings(
+        client_id="id", client_secret="secret", refresh_token="refresh", shared_album_id="album"
+    )
+    client = GooglePhotosClient(settings, session=session, clock=lambda: 0)
+
+    items = client.list_media_items("album")
+
+    assert [item["id"] for item in items] == ["1"]
+    assert session.media_call_count == 2
+    assert session.media_requests[0].get("pageSize") == 50
+    assert "pageSize" not in session.media_requests[1]
+
+
+def test_fetch_album_images_uses_cache(monkeypatch):
+    google_photos._CACHE.clear()
+    google_photos._ALBUM_CACHE = None
+
+    calls = {"count": 0}
+
+    def list_media_items(_album_id):
+        calls["count"] += 1
+        return [
+            {"mimeType": "image/jpeg", "baseUrl": "https://example.com/photo"},
+        ]
+
+    client = SimpleNamespace(
+        settings=SimpleNamespace(shared_album_id="album"),
+        list_media_items=list_media_items,
+    )
+
+    monkeypatch.setattr(google_photos, "get_google_photos_client", lambda: client)
+
+    first = google_photos.fetch_album_images("https://photos.app.goo.gl/demo")
+    second = google_photos.fetch_album_images("https://photos.app.goo.gl/demo")
+
+    assert first == ["https://example.com/photo=w2048"]
+    assert second == first
+    assert calls["count"] == 1
+
+
+def test_fetch_album_images_filters_avatars(monkeypatch):
+    google_photos._CACHE.clear()
+    google_photos._ALBUM_CACHE = None
+
+    items = [
+        {"mimeType": "image/jpeg", "baseUrl": "https://example.com/avatar", "filename": "avatar.jpg"},
+        {"mimeType": "image/png", "baseUrl": "https://example.com/keep", "filename": "holiday.png"},
+        {"mimeType": "video/mp4", "baseUrl": "https://example.com/video"},
+    ]
+
+    client = SimpleNamespace(
+        settings=SimpleNamespace(shared_album_id="album"),
+        list_media_items=lambda _album_id: items,
+    )
+    monkeypatch.setattr(google_photos, "get_google_photos_client", lambda: client)
+
+    results = google_photos.fetch_album_images("https://photos.app.goo.gl/demo")
+
+    assert results == ["https://example.com/keep=w2048"]
+
+
+def test_fetch_album_images_by_album_id(monkeypatch):
+    google_photos._CACHE.clear()
+    google_photos._ALBUM_CACHE = None
+
+    client = SimpleNamespace(
+        settings=SimpleNamespace(shared_album_id="album"),
+        list_media_items=lambda album_id: [
+            {"mimeType": "image/jpeg", "baseUrl": "https://example.com/album"},
+        ],
+    )
+    monkeypatch.setattr(google_photos, "get_google_photos_client", lambda: client)
+
+    results = google_photos.fetch_album_images(album_id="custom-id")
+
+    assert results == ["https://example.com/album=w2048"]
+    assert "id:custom-id" in google_photos._CACHE
+
+
+def test_list_google_photos_albums_sorts_and_deduplicates(monkeypatch):
+    google_photos._ALBUM_CACHE = None
+
+    albums = [
+        {
+            "id": "2",
+            "title": "Weekend Road Trip",
+            "mediaItemsCount": "5",
+            "productUrl": "https://photos.example/albums/2",
+        },
+        {
+            "id": "1",
+            "title": "Beach Day",
+            "coverPhotoBaseUrl": "https://photos.example/cover",
+            "productUrl": "https://photos.example/albums/1",
+        },
+        {
+            "id": "1",
+            "title": "Duplicate",
+            "productUrl": "https://photos.example/albums/1b",
+        },
+    ]
+
+    client = SimpleNamespace(list_albums=lambda: albums)
+    monkeypatch.setattr(google_photos, "get_google_photos_client", lambda: client)
+
+    result = google_photos.list_google_photos_albums(force_refresh=True)
+
+    assert [album["id"] for album in result] == ["1", "2"]
+    assert result[0]["title"] == "Beach Day"
+    assert result[0]["cover_photo_url"] == "https://photos.example/cover=w2048"
+
+
+def test_google_photos_client_album_listing_retries_without_page_size(token_store_path):
+    error_payload = {"error": {"message": "Page size must be less than or equal to 50."}}
+    album_pages = [
+        FakeResponse(error_payload, status_code=400, text=json.dumps(error_payload)),
+        {"albums": [{"id": "1", "title": "Album"}]},
+        {"sharedAlbums": []},
+    ]
+    session = FakeSession([], album_pages=album_pages)
+    settings = GooglePhotosSettings(
+        client_id="id", client_secret="secret", refresh_token="refresh", shared_album_id="album"
+    )
+    client = GooglePhotosClient(settings, session=session, clock=lambda: 0)
+
+    albums = client.list_albums()
+
+    assert [album.get("id") for album in albums] == ["1"]
+    assert session.album_call_count == 3
+    assert session.album_requests[0].get("pageSize") == 50
+    assert "pageSize" not in session.album_requests[1]
+
+
+def test_oauth_helper_builds_expected_authorization_url():
+    config = google_photos_oauth.OAuthClientConfig(
+        client_id="client",
+        client_secret="secret",
+        redirect_port=9999,
+    )
+
+    url = google_photos_oauth._build_auth_url(config, scope="scope", state="state123")
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+
+    assert params["client_id"] == ["client"]
+    assert params["redirect_uri"] == [config.redirect_uri]
+    assert params["scope"] == ["scope"]
+    assert params["state"] == ["state123"]
+
+
+def test_oauth_helper_finds_free_port():
+    port = google_photos_oauth._find_free_port(9876)
+    assert isinstance(port, int)
+    assert 0 < port < 65536
+
+
+def test_google_photos_oauth_start_sets_state_and_redirects(app_with_oauth):
+    client = app_with_oauth.test_client()
+
+    response = client.get("/auth/google/start")
+
+    assert response.status_code == 302
+    assert "accounts.google.com" in response.headers["Location"]
+
+    parsed = urlparse(response.headers["Location"])
+    params = parse_qs(parsed.query)
+    assert params["response_type"] == ["code"]
+    assert params["scope"] == [DEFAULT_GOOGLE_PHOTOS_OAUTH_SCOPE]
+
+    with client.session_transaction() as flask_session:
+        assert routes._OAUTH_STATE_SESSION_KEY in flask_session
+        assert flask_session[routes._OAUTH_STATE_SESSION_KEY]
+
+
+def test_google_photos_oauth_callback_persists_tokens(monkeypatch, app_with_oauth, token_store_path):
+    class TokenResponse:
+        status_code = 200
+        text = "{}"
+
+        def json(self):
+            return {"refresh_token": "refresh-token", "access_token": "access-token"}
+
+    monkeypatch.setattr(routes.requests, "post", lambda url, data, timeout: TokenResponse())
+    resets = {"count": 0}
+
+    def fake_reset():
+        resets["count"] += 1
+
+    monkeypatch.setattr(routes, "reset_google_photos_client", fake_reset)
+
+    client = app_with_oauth.test_client()
+    with client.session_transaction() as flask_session:
+        flask_session[routes._OAUTH_STATE_SESSION_KEY] = "state-123"
+
+    response = client.get(
+        "/auth/google/callback",
+        query_string={"state": "state-123", "code": "auth-code"},
+    )
+
+    assert response.status_code == 200
+    assert b"WanderLog saved your Google Photos credentials" in response.data
+    assert str(token_store_path).encode("utf-8") in response.data
+    stored = json.loads(token_store_path.read_text())
+    assert stored["refresh_token"] == "refresh-token"
+    assert stored["access_token"] == "access-token"
+    assert resets["count"] == 1
+
+
+def test_google_photos_oauth_callback_rejects_invalid_state(app_with_oauth):
+    client = app_with_oauth.test_client()
+
+    response = client.get(
+        "/auth/google/callback",
+        query_string={"state": "unexpected", "code": "ignored"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_google_photos_logout_clears_token_store_and_env(monkeypatch, app_with_oauth, token_store_path):
+    token_store.save_tokens(refresh_token="stored-refresh", access_token="stored-access", expires_in=3600)
+    monkeypatch.setenv("GOOGLE_PHOTOS_REFRESH_TOKEN", "env-refresh")
+
+    client = app_with_oauth.test_client()
+    response = client.post("/auth/google/logout")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["tokens_removed"] is True
+    assert not token_store_path.exists()
+    assert "GOOGLE_PHOTOS_REFRESH_TOKEN" not in os.environ
+
+
+def test_google_photos_token_status_reports_validity(app_with_oauth, token_store_path):
+    now = time.time()
+    token_store.save_tokens(
+        refresh_token="stored-refresh",
+        access_token="stored-access",
+        expires_in=3600,
+        clock=lambda: now,
+    )
+
+    client = app_with_oauth.test_client()
+    response = client.get("/api/google_photos/token_status")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    assert payload["connected"] is True
+    assert payload["refresh_token_present"] is True
+    assert payload["access_token_present"] is True
+    assert payload["access_token_valid"] is True
+    assert payload["access_token_expires_at"] >= now
+
+
+def test_token_store_persists_refresh_token(token_store_path):
+    payload = token_store.save_tokens(
+        refresh_token="stored-refresh",
+        access_token="stored-access",
+        expires_in=3600,
+        clock=lambda: 1000,
+    )
+
+    assert payload["refresh_token"] == "stored-refresh"
+    on_disk = json.loads(token_store_path.read_text())
+    assert on_disk["refresh_token"] == "stored-refresh"
+    assert on_disk["access_token"] == "stored-access"
+    assert on_disk["expires_at"] == 4600
+
+
+def test_token_store_falls_back_to_writable_directory(monkeypatch, tmp_path):
+    locked = tmp_path / "locked"
+    fallback = tmp_path / "fallback"
+
+    monkeypatch.delenv("GOOGLE_PHOTOS_TOKEN_STORE_PATH", raising=False)
+    monkeypatch.setattr(token_store, "_candidate_directories", lambda: [locked, fallback])
+
+    original_access = token_store.os.access
+
+    def fake_access(path, mode):
+        candidate = Path(path)
+        if candidate == locked:
+            return False
+        if candidate == fallback:
+            return True
+        return original_access(path, mode)
+
+    monkeypatch.setattr(token_store.os, "access", fake_access)
+
+    payload = token_store.save_tokens(refresh_token="fallback-token")
+
+    assert payload["refresh_token"] == "fallback-token"
+    stored_path = fallback / "google_photos_tokens.json"
+    assert stored_path.exists()
+
+
+def test_token_store_uses_temp_directory_when_all_candidates_fail(monkeypatch, tmp_path):
+    locked = tmp_path / "locked"
+    locked.mkdir()
+
+    temp_root = tmp_path / "temp"
+    monkeypatch.delenv("GOOGLE_PHOTOS_TOKEN_STORE_PATH", raising=False)
+    monkeypatch.setattr(token_store, "_candidate_directories", lambda: [locked])
+    monkeypatch.setattr(token_store.tempfile, "gettempdir", lambda: str(temp_root))
+
+    original_access = token_store.os.access
+
+    def fake_access(path, mode):
+        candidate = Path(path)
+        if candidate == locked:
+            return False
+        return original_access(path, mode)
+
+    monkeypatch.setattr(token_store.os, "access", fake_access)
+
+    payload = token_store.save_tokens(refresh_token="temp-token")
+
+    assert payload["refresh_token"] == "temp-token"
+    stored_path = temp_root / "wanderlog" / "google_photos_tokens.json"
+    assert stored_path.exists()
+
+
+def test_token_store_raises_helpful_error_for_unwritable_override(monkeypatch, tmp_path):
+    override = tmp_path / "tokens.json"
+    monkeypatch.setenv("GOOGLE_PHOTOS_TOKEN_STORE_PATH", str(override))
+
+    original_open = token_store.Path.open
+
+    def fake_open(self, *args, **kwargs):
+        if self == override:
+            raise PermissionError("denied")
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(token_store.Path, "open", fake_open)
+
+    with pytest.raises(RuntimeError) as exc:
+        token_store.save_tokens(refresh_token="value")
+
+    assert "GOOGLE_PHOTOS_TOKEN_STORE_PATH" in str(exc.value)
+
+
+def test_load_google_photos_settings_uses_saved_refresh_token(monkeypatch, token_store_path):
+    token_store.save_tokens(refresh_token="persisted", access_token="ignored")
+    monkeypatch.setenv("GOOGLE_PHOTOS_CLIENT_ID", "client-id")
+    monkeypatch.setenv("GOOGLE_PHOTOS_CLIENT_SECRET", "client-secret")
+    monkeypatch.delenv("GOOGLE_PHOTOS_REFRESH_TOKEN", raising=False)
+
+    settings = routes.load_google_photos_settings()
+
+    assert settings.refresh_token == "persisted"


### PR DESCRIPTION
## Summary
- add operating system config and temp-directory fallbacks when resolving the Google Photos token store path
- guard token loads when no writable directory exists and document the new persistence locations
- extend the Google Photos token store tests to cover the temporary-directory fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7060ea70c832992905ccea4f0529a