### PR TITLE
Relax OAuthlib restrictions for non-production builds

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,10 @@ from . import data_cache, trip_store
 def create_app():
     load_dotenv()
 
+    if os.getenv("FLASK_ENV") != "production":
+        os.environ.setdefault("OAUTHLIB_INSECURE_TRANSPORT", "1")
+        os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")
+
     app = Flask(__name__)
 
     # Load cached timeline data once during application startup

--- a/readme.txt
+++ b/readme.txt
@@ -5,3 +5,4 @@ v0.3 - added dates to map marker popup data.  Made map rendering dynamic, and fa
 v0.4 - updated UI, added data type filtering, cleaned up code
 v0.5 - added archiving/deleting of data points, backups for timeline data on clear map, warnings for clear map & deleting of data points, and date range filtering
 v0.6 - added "Trips" prototype, added edit mode with multi-selection/editing of data points, updates to UI, fixed sorting, added descriptions to Trips
+v0.7 - development builds now relax OAuthlib HTTPS enforcement when FLASK_ENV is not set to "production"; production deployments still require HTTPS


### PR DESCRIPTION
## Summary
- allow the Flask app to default OAuthlib to insecure transport and relaxed token scope when FLASK_ENV is not production
- document the new development behavior in the project changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8be413c048329b67a4e5255d00af1