### PR TITLE
Document Google integrations without disabling them

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -465,6 +465,9 @@ function setElementHidden(element, hidden) {
     else { element.hidden = false; }
 }
 
+// Convert the payload returned by ``/api/auth/status`` into a predictable
+// structure that the UI can work with.  This mirrors the server-side
+// ``_normalise_google_user`` helper.
 function normaliseGoogleAuthUser(user) {
     if (!user || typeof user !== 'object') { return null; }
 
@@ -478,6 +481,8 @@ function normaliseGoogleAuthUser(user) {
     return { id, email, name, picture };
 }
 
+// Build an initial (for the avatar badge) based on the user's display name or
+// email address returned from Google.
 function deriveGoogleUserInitial(user) {
     if (!user) { return ''; }
     const source = (user.name || user.email || '').trim();
@@ -485,6 +490,8 @@ function deriveGoogleUserInitial(user) {
     return source.charAt(0).toUpperCase();
 }
 
+// Persist the current Google user in the global config object so other modules
+// can query authentication state without touching the DOM directly.
 function updateGoogleAuthConfig(user) {
     if (!GOOGLE_AUTH_CONFIG) { return; }
     if (user) {
@@ -494,6 +501,9 @@ function updateGoogleAuthConfig(user) {
     }
 }
 
+// Update the Google authentication card UI to reflect the latest state.  This
+// controls the sign-in button label, the avatar, and the album tester
+// visibility based on whether the user is authenticated.
 function applyGoogleAuthState(state) {
     const card = document.querySelector('[data-google-auth-card]');
     if (!card) { return; }
@@ -601,6 +611,9 @@ function applyGoogleAuthState(state) {
     updateGoogleAuthConfig(normalisedUser);
 }
 
+// Ask the backend whether the current session is authenticated with Google.
+// The endpoint both validates stored credentials and returns a minimal user
+// profile so the UI can react accordingly.
 async function requestGoogleAuthStatus() {
     if (!GOOGLE_AUTH_CONFIG || !GOOGLE_AUTH_CONFIG.enabled) { return; }
     if (!document.querySelector('[data-google-auth-card]')) { return; }
@@ -624,6 +637,8 @@ async function requestGoogleAuthStatus() {
     }
 }
 
+// Bind the Google authentication card to live data by applying the initial
+// state from ``GOOGLE_AUTH_CONFIG`` and triggering a status refresh.
 function setupGoogleAuthCard() {
     if (!GOOGLE_AUTH_CONFIG || !GOOGLE_AUTH_CONFIG.enabled) { return; }
     if (!document.querySelector('[data-google-auth-card]')) { return; }
@@ -637,6 +652,9 @@ function setupGoogleAuthCard() {
     requestGoogleAuthStatus();
 }
 
+// Wire up the optional "Google Photos albums" tester.  When triggered it calls
+// our backend, which in turn queries the Google Photos Library API with the
+// stored OAuth credentials.
 function setupGooglePhotosAlbumsTester() {
     const card = document.querySelector('[data-google-auth-card]');
     if (!card) { return; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -25,6 +25,11 @@
         </button>
         <div class="overlay-controls" id="menuControls" aria-hidden="true" inert>
             {% if google_auth_enabled %}
+            {#
+                When Google OAuth is configured we render a dedicated account
+                card.  The JavaScript initialises behaviour by querying these
+                ``data-`` attributes once the page loads.
+            #}
             <section class="auth-card" aria-label="Account" data-google-auth-card>
                 <div class="auth-card-status" data-auth-status {% if not google_user %}hidden{% endif %}>
                     <span class="auth-card-avatar" data-auth-avatar aria-hidden="true">
@@ -56,6 +61,11 @@
                     {% set auth_button_href = url_for('main.google_auth_start') %}
                     {% set auth_button_label = "Sign in with Google" %}
                 {% endif %}
+                {#
+                    ``data-auth-*`` attributes capture the alternative labels,
+                    URLs, and CSS classes so the front-end can swap between
+                    "Sign in" and "Sign out" states without extra templates.
+                #}
                 <a
                     class="{{ ' '.join(auth_button_classes) }}"
                     href="{{ auth_button_href }}"
@@ -72,6 +82,12 @@
                     </span>
                     <span data-auth-button-label>{{ auth_button_label }}</span>
                 </a>
+                {#
+                    The album tester button surfaces Google Photos albums using
+                    the stored OAuth credentials.  It remains disabled until the
+                    user signs in so we never attempt API calls without a
+                    token.
+                #}
                 <button
                     type="button"
                     class="overlay-button auth-card-albums-button"


### PR DESCRIPTION
## Summary
- restore the Google OAuth and Photos code paths while adding inline comments that describe each step of the flow
- document the front-end Google auth helpers, template data attributes, and Google Photos scraping utility so their behaviour is clear
- re-enable the Google auth dependencies now that the integrations remain active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e51462674883298aee47037fea7afc