### PR TITLE
Remove Google Photos album integration

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1290,64 +1290,6 @@ button, input, select { font-family: inherit; }
     gap: 10px;
 }
 
-.auth-card-albums-button {
-    width: 100%;
-    justify-content: center;
-}
-
-.auth-card-albums {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding-top: 10px;
-    border-top: 1px solid rgba(209, 213, 219, 0.8);
-}
-
-.auth-card-albums-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.auth-card-albums-item {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.auth-card-albums-item a {
-    color: #1d4ed8;
-    font-weight: 600;
-    text-decoration: none;
-}
-
-.auth-card-albums-item a:hover,
-.auth-card-albums-item a:focus-visible {
-    text-decoration: underline;
-}
-
-.auth-card-albums-meta {
-    font-size: 13px;
-    color: #4b5563;
-}
-
-.auth-card-albums-empty,
-.auth-card-albums-error {
-    font-size: 14px;
-    margin: 0;
-}
-
-.auth-card-albums-error {
-    color: #b91c1c;
-}
-
-.auth-card-album-link-disabled {
-    color: #6b7280;
-    pointer-events: none;
-}
 
 .auth-card-status {
     display: flex;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -82,27 +82,6 @@
                     </span>
                     <span data-auth-button-label>{{ auth_button_label }}</span>
                 </a>
-                {#
-                    The album tester button surfaces Google Photos albums using
-                    the stored OAuth credentials.  It remains disabled until the
-                    user signs in so we never attempt API calls without a
-                    token.
-                #}
-                <button
-                    type="button"
-                    class="overlay-button auth-card-albums-button"
-                    data-auth-albums-button
-                    data-auth-albums-default-label="View Google Photos Albums"
-                    data-auth-albums-loading-label="Loading albums..."
-                    {% if not google_user %}hidden disabled{% endif %}
-                >
-                    <span data-auth-albums-button-label>View Google Photos Albums</span>
-                </button>
-                <div class="auth-card-albums" data-auth-albums-section hidden>
-                    <p class="auth-card-albums-empty" data-auth-albums-empty hidden>No albums found for this account.</p>
-                    <p class="auth-card-albums-error" data-auth-albums-error role="alert" hidden></p>
-                    <ul class="auth-card-albums-list" data-auth-albums-list hidden></ul>
-                </div>
             </section>
             {% endif %}
             <div class="overlay-tabs-wrapper">


### PR DESCRIPTION
## Summary
- remove the unused Google Photos album OAuth scope and helper endpoint
- strip the Google Photos album tester UI and related JavaScript
- clean up styles that only supported the removed album tester controls

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e573ed6bd08329aa3a902216eb0064